### PR TITLE
Add file system and cluster-level statistics.

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -88,6 +88,18 @@ var (
 			help:   "Limit size in bytes for breaker",
 			labels: []string{"breaker"},
 		},
+		"filesystem_data_available_bytes": {
+			help:   "Available space on block device in bytes",
+			labels: []string{"mount", "path"},
+		},
+		"filesystem_data_free_bytes": {
+			help:   "Free space on block device in bytes",
+			labels: []string{"mount", "path"},
+		},
+		"filesystem_data_size_bytes": {
+			help:   "Size of block device in bytes",
+			labels: []string{"mount", "path"},
+		},
 		"jvm_memory_committed_bytes": {
 			help:   "JVM memory currently committed by area",
 			labels: []string{"area"},
@@ -369,6 +381,13 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		e.counterVecs["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Host, "total").Set(float64(stats.Process.CPU.Total / 1000))
 		e.counterVecs["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Host, "sys").Set(float64(stats.Process.CPU.Sys / 1000))
 		e.counterVecs["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Host, "user").Set(float64(stats.Process.CPU.User / 1000))
+
+		// File System Stats
+		for _, fsStats := range stats.FS.Data {
+			e.gaugeVecs["filesystem_data_available_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, fsStats.Mount, fsStats.Path).Set(float64(fsStats.Available))
+			e.gaugeVecs["filesystem_data_free_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, fsStats.Mount, fsStats.Path).Set(float64(fsStats.Free))
+			e.gaugeVecs["filesystem_data_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, fsStats.Mount, fsStats.Path).Set(float64(fsStats.Total))
+		}
 	}
 
 	// Report metrics.

--- a/main.go
+++ b/main.go
@@ -37,13 +37,13 @@ func main() {
 	)
 	flag.Parse()
 
+	nodesStatsURI := *esURI + "/_nodes/_local/stats"
 	if *esAllNodes {
-		*esURI = *esURI + "/_nodes/stats"
-	} else {
-		*esURI = *esURI + "/_nodes/_local/stats"
+		nodesStatsURI = *esURI + "/_nodes/stats"
 	}
+	clusterHealthURI := *esURI + "/_cluster/health"
 
-	exporter := NewExporter(*esURI, *esTimeout, *esAllNodes)
+	exporter := NewExporter(nodesStatsURI, clusterHealthURI, *esTimeout, *esAllNodes)
 	prometheus.MustRegister(exporter)
 
 	log.Println("Starting Server:", *listenAddress)

--- a/struct.go
+++ b/struct.go
@@ -259,3 +259,21 @@ type NodeStatsFSDataResponse struct {
 	DiskReadSize  int64  `json:"disk_read_size_in_bytes"`
 	DiskWriteSize int64  `json:"disk_write_size_in_bytes"`
 }
+
+// Elasticsearch Cluster Health Struct
+
+type ClusterHealthResponse struct {
+	ActivePrimaryShards     int64  `json:"active_primary_shards"`
+	ActiveShards            int64  `json:"active_shards"`
+	ClusterName             string `json:"cluster_name"`
+	DelayedUnassignedShards int64  `json:"delayed_unassigned_shards"`
+	InitializingShards      int64  `json:"initializing_shards"`
+	NumberOfDataNodes       int64  `json:"number_of_data_nodes"`
+	NumberOfInFlightFetch   int64  `json:"number_of_in_flight_fetch"`
+	NumberOfNodes           int64  `json:"number_of_nodes"`
+	NumberOfPendingTasks    int64  `json:"number_of_pending_tasks"`
+	RelocatingShards        int64  `json:"relocating_shards"`
+	Status                  string `json:"status"`
+	TimedOut                bool   `json:"timed_out"`
+	UnassignedShards        int64  `json:"unassigned_shards"`
+}


### PR DESCRIPTION
We'd like to keep track of whether Elasticsearch is failing due to full
disks. We already have these metrics declared in the structures. Let's
just export them as metrics as well. While there, also start scraping `/_cluster/health`, so we get access to global data.