### PR TITLE
Further health metrics

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -170,6 +170,18 @@ var (
 		prometheus.BuildFQName(namespace, "cluster_health", "status_is_green"),
 		"Whether all primary and replica shards are allocated.",
 		[]string{"cluster"}, nil)
+	clusterHealthStatusDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "cluster_health", "status"),
+		"Whether all primary and replica shards are allocated.",
+		[]string{"cluster","color"}, nil)
+	clusterHealthStatusIsYellowDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "cluster_health", "status_is_yellow"),
+		"Whether all primary and replica shards are allocated.",
+		[]string{"cluster"}, nil)
+	clusterHealthStatusIsRedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "cluster_health", "status_is_red"),
+		"Whether all primary and replica shards are allocated.",
+		[]string{"cluster"}, nil)
 	clusterHealthTimedOutDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "cluster_health", "timed_out"),
 		"XXX WHAT DOES THIS MEAN?",
@@ -488,11 +500,28 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(clusterHealthRelocatingShardsDesc, prometheus.GaugeValue, float64(clusterHealth.RelocatingShards), clusterHealth.ClusterName)
 	ch <- prometheus.MustNewConstMetric(clusterHealthUnassignedShardsDesc, prometheus.GaugeValue, float64(clusterHealth.UnassignedShards), clusterHealth.ClusterName)
 
+	healthStatus := 0.0
 	statusIsGreen := 0.0
 	if clusterHealth.Status == "green" {
 		statusIsGreen = 1.0
+		healthStatus = 0.0
 	}
 	ch <- prometheus.MustNewConstMetric(clusterHealthStatusIsGreenDesc, prometheus.GaugeValue, statusIsGreen, clusterHealth.ClusterName)
+
+	statusIsYellow := 0.0
+	if clusterHealth.Status == "yellow" {
+		statusIsYellow = 1.0
+		healthStatus = 1.0
+	}
+	ch <- prometheus.MustNewConstMetric(clusterHealthStatusIsYellowDesc, prometheus.GaugeValue, statusIsYellow, clusterHealth.ClusterName)
+
+	statusIsRed := 0.0
+	if clusterHealth.Status == "red" {
+		statusIsRed = 1.0
+		healthStatus = 2.0
+	}
+	ch <- prometheus.MustNewConstMetric(clusterHealthStatusIsRedDesc, prometheus.GaugeValue, statusIsRed, clusterHealth.ClusterName)
+        ch <- prometheus.MustNewConstMetric(clusterHealthStatusDesc,prometheus.GaugeValue,healthStatus,clusterHealth.ClusterName,clusterHealth.Status)
 
 	timedOut := 0.0
 	if clusterHealth.TimedOut {


### PR DESCRIPTION
I have created two further metrics to complement status_is_green:

- status_is_yellow
- status_is_red

I also implemented a gauge metric 'status' to provide a 0, 1 or 2 on cluster state. (0=green, 1=yellow, 2=red)
Primarily I wanted this to be able to determine cluster health by querying a single metric.