### PR TITLE
Add tripped metric

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -88,6 +88,10 @@ var (
 			help:   "Limit size in bytes for breaker",
 			labels: []string{"breaker"},
 		},
+		"breakers_tripped": {
+			help:   "tripped for breaker",
+			labels: []string{"breaker"},
+		},
 		"filesystem_data_available_bytes": {
 			help:   "Available space on block device in bytes",
 			labels: []string{"mount", "path"},
@@ -358,6 +362,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		for breaker, bstats := range stats.Breakers {
 			e.gaugeVecs["breakers_estimated_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, breaker).Set(float64(bstats.EstimatedSize))
 			e.gaugeVecs["breakers_limit_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, breaker).Set(float64(bstats.LimitSize))
+			e.gaugeVecs["breakers_tripped"].WithLabelValues(allStats.ClusterName, stats.Host, breaker).Set(float64(bstats.Tripped))
 		}
 
 		// Thread Pool stats


### PR DESCRIPTION
According to https://www.elastic.co/guide/en/elasticsearch/guide/current/_monitoring_individual_nodes.html#_circuit_breaker , ```The main thing to watch is the tripped metric.```