### PR TITLE
Build and push docker image automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 language: go
 
+sudo: required
+
+services:
+- docker
+
 go:
   - 1.8.x
-  - tip
 
 script:
   - make style
   - make vet
   - make test
   - make build
+  - make docker
+  - make push
+
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_NAME       ?= elasticsearch-exporter
-DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+DOCKER_IMAGE_TAG        ?= $(TRAVIS_BRANCH)
 
 
 all: format build test
@@ -50,6 +50,11 @@ tarball: promu
 docker:
 	@echo ">> building docker image"
 	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+
+push:
+	@echo ">> pushing docker image"
+	@docker login -u="$(DOCKER_USERNAME)" -p="$(DOCKER_PASSWORD)" quay.io
+	@docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
 promu:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \


### PR DESCRIPTION
- ignore go tip for now

addresses: https://github.com/justwatchcom/elasticsearch_exporter/issues/26

TODO:
create a repository on quay
create a robot user for that repository on quay, copy the docker login path
```
travis env set DOCKER_USERNAME <quay_io_robot_username>
travis env set DOCKER_PASSWORD <quay_io_robot_password>
travis env set DOCKER_IMAGE_NAME quay.io/<organisation>/elasticsearch_exporter
```