### PR TITLE
Support user and password to request when basicAuth is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ elasticsearch_exporter --help
 | es.timeout          | Timeout for trying to get stats from Elasticsearch. (ex: 20s) |
 | web.listen-address  | Address to listen on for web interface and telemetry. |
 | web.telemetry-path  | Path under which to expose metrics. |
+| es.user             | User to use if elasticsearch basicAuth is enabled
+| es.password         | Password to use if elasticsearch basicAuth is enabled
 
 __NOTE:__ We support pulling stats for all nodes at once, but in production
 this is unlikely to be the way you actually want to run the system. It is much

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ func main() {
 		esURI         = flag.String("es.uri", "http://localhost:9200", "HTTP API address of an Elasticsearch node.")
 		esTimeout     = flag.Duration("es.timeout", 5*time.Second, "Timeout for trying to get stats from Elasticsearch.")
 		esAllNodes    = flag.Bool("es.all", false, "Export stats for all nodes in the cluster.")
+		esUser        = flag.String("es.user", "", "ElasticSearch user")
+		esPassword    = flag.String("es.password", "", "Elasticsearch password")
 	)
 	flag.Parse()
 
@@ -43,7 +45,7 @@ func main() {
 	}
 	clusterHealthURI := *esURI + "/_cluster/health"
 
-	exporter := NewExporter(nodesStatsURI, clusterHealthURI, *esTimeout, *esAllNodes)
+	exporter := NewExporter(nodesStatsURI, clusterHealthURI, *esTimeout, *esAllNodes, *esUser, *esPassword)
 	prometheus.MustRegister(exporter)
 
 	log.Println("Starting Server:", *listenAddress)


### PR DESCRIPTION
Hi,

If ElasticSearch is protected by basicAuth, the exporter must be able to request cluster stats.
Expected command line would be :
```
elasticsearch_exporter -es.uri http://localhost:9200 -es.user myuser -es.password mypassword
```