### PR TITLE
Fixed docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Example `docker-compose.yml`:
 ```yaml
 elasticsearch_exporter:
     image: justwatch/elasticsearch_exporter:1.0.0-rc1
-    environment:
-    - '-es.uri=http://elasticsearch:9200'
+    command:
+     - '-es.uri=http://elasticsearch:9200'
     restart: always
     ports:
     - "127.0.0.1:9108:9108"


### PR DESCRIPTION
I didn't get the exporter to find the elasticsearch cluster when following the docker-compose example at first but then I noticed that the command argument was declared as an environment variable. Changing that fixed it for me.