### PR TITLE
add cache metrics

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -12,13 +12,11 @@ import (
 )
 
 var (
-	defaultNodeLabels          = []string{"cluster", "host", "name"}
-	defaultThreadPoolLabels    = append(defaultNodeLabels, "type")
-	defaultBreakerLabels       = append(defaultNodeLabels, "breaker")
-	defaultFilesystemLabels    = append(defaultNodeLabels, "mount", "path")
-	defaultCacheCategoryLabels = append(defaultNodeLabels, "category")
-	defaultCacheHitLabels      = append(defaultNodeLabels, "hit")
-	defaultCacheMissLabels     = append(defaultNodeLabels, "miss")
+	defaultNodeLabels       = []string{"cluster", "host", "name"}
+	defaultThreadPoolLabels = append(defaultNodeLabels, "type")
+	defaultBreakerLabels    = append(defaultNodeLabels, "breaker")
+	defaultFilesystemLabels = append(defaultNodeLabels, "mount", "path")
+	defaultCacheLabels      = append(defaultNodeLabels, "cache")
 
 	defaultNodeLabelValues = func(cluster string, node NodeStatsNodeResponse) []string {
 		return []string{cluster, node.Host, node.Name}
@@ -29,6 +27,12 @@ var (
 	defaultFilesystemLabelValues = func(cluster string, node NodeStatsNodeResponse, mount string, path string) []string {
 		return append(defaultNodeLabelValues(cluster, node), mount, path)
 	}
+	defaultCacheHitLabelValues = func(cluster string, node NodeStatsNodeResponse) []string {
+		return append(defaultNodeLabelValues(cluster, node), "hit")
+	}
+	defaultCacheMissLabelValues = func(cluster string, node NodeStatsNodeResponse) []string {
+		return append(defaultNodeLabelValues(cluster, node), "miss")
+	}
 )
 
 type nodeMetric struct {
@@ -36,16 +40,6 @@ type nodeMetric struct {
 	Desc   *prometheus.Desc
 	Value  func(node NodeStatsNodeResponse) float64
 	Labels func(cluster string, node NodeStatsNodeResponse) []string
-}
-
-type nodeMetricVec struct {
-	Subsystem   string
-	Name        string
-	Help        string
-	Desc        func(subsystem string, name string, help string) *prometheus.Desc
-	Labels      []string
-	LabelValues func(cluster string, node NodeStatsNodeResponse) [][]string
-	Values      func(node NodeStatsNodeResponse) []float64
 }
 
 type gcCollectionMetric struct {
@@ -86,7 +80,6 @@ type Nodes struct {
 	totalScrapes, jsonParseFailures prometheus.Counter
 
 	nodeMetrics         []*nodeMetric
-	nodeMetricsVec      []*nodeMetricVec
 	gcCollectionMetrics []*gcCollectionMetric
 	breakerMetrics      []*breakerMetric
 	threadPoolMetrics   []*threadPoolMetric
@@ -112,43 +105,6 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 			Name: prometheus.BuildFQName(namespace, "node_stats", "json_parse_failures"),
 			Help: "Number of errors while parsing JSON.",
 		}),
-
-		nodeMetricsVec: []*nodeMetricVec{
-			{
-				Subsystem: "indices",
-				Name:      "query_cache_count",
-				Help:      "Query cache count",
-				Desc: func(subsystem string, name string, help string) *prometheus.Desc {
-					return prometheus.NewDesc(
-						prometheus.BuildFQName(namespace, subsystem, name),
-						help, defaultCacheCategoryLabels, nil)
-				},
-				Labels: defaultCacheCategoryLabels,
-				LabelValues: func(cluster string, node NodeStatsNodeResponse) [][]string {
-					return [][]string{defaultCacheHitLabels, defaultCacheMissLabels}
-				},
-				Values: func(node NodeStatsNodeResponse) []float64 {
-					return []float64{float64(node.Indices.QueryCache.HitCount), float64(node.Indices.QueryCache.MissCount)}
-				},
-			},
-			{
-				Subsystem: "indices",
-				Name:      "request_cache_count",
-				Help:      "Request cache count",
-				Desc: func(subsystem string, name string, help string) *prometheus.Desc {
-					return prometheus.NewDesc(
-						prometheus.BuildFQName(namespace, subsystem, name),
-						help, defaultCacheCategoryLabels, nil)
-				},
-				Labels: defaultCacheCategoryLabels,
-				LabelValues: func(cluster string, node NodeStatsNodeResponse) [][]string {
-					return [][]string{defaultCacheHitLabels, defaultCacheMissLabels}
-				},
-				Values: func(node NodeStatsNodeResponse) []float64 {
-					return []float64{float64(node.Indices.RequestCache.HitCount), float64(node.Indices.RequestCache.MissCount)}
-				},
-			},
-		},
 
 		nodeMetrics: []*nodeMetric{
 			{
@@ -260,6 +216,30 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 				Labels: defaultNodeLabelValues,
 			},
 			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "query_cache_count"),
+					"Query cache count",
+					defaultCacheLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.QueryCache.HitCount)
+				},
+				Labels: defaultCacheHitLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "query_cache_count"),
+					"Query cache count",
+					defaultCacheLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.QueryCache.MissCount)
+				},
+				Labels: defaultCacheMissLabelValues,
+			},
+			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices", "request_cache_memory_size_bytes"),
@@ -282,6 +262,30 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 					return float64(node.Indices.RequestCache.Evictions)
 				},
 				Labels: defaultNodeLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "request_cache_count"),
+					"Request cache count",
+					defaultCacheLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.RequestCache.HitCount)
+				},
+				Labels: defaultCacheHitLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "request_cache_count"),
+					"Request cache count",
+					defaultCacheLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.RequestCache.MissCount)
+				},
+				Labels: defaultCacheMissLabelValues,
 			},
 			{
 				Type: prometheus.CounterValue,
@@ -1057,9 +1061,6 @@ func (c *Nodes) Describe(ch chan<- *prometheus.Desc) {
 	for _, metric := range c.nodeMetrics {
 		ch <- metric.Desc
 	}
-	for _, metric := range c.nodeMetricsVec {
-		ch <- metric.Desc(metric.Subsystem, metric.Name, metric.Help)
-	}
 	for _, metric := range c.gcCollectionMetrics {
 		ch <- metric.Desc
 	}
@@ -1127,22 +1128,6 @@ func (c *Nodes) Collect(ch chan<- prometheus.Metric) {
 				metric.Value(node),
 				metric.Labels(nodeStatsResponse.ClusterName, node)...,
 			)
-		}
-		for _, metric := range c.nodeMetricsVec {
-			labelValues := metric.LabelValues(nodeStatsResponse.ClusterName, node)
-			values := metric.Values(node)
-
-			for i, labelValue := range labelValues {
-				counterVec := prometheus.NewCounterVec(prometheus.CounterOpts{
-					Namespace: namespace,
-					Subsystem: metric.Subsystem,
-					Name:      metric.Name,
-					Help:      metric.Help},
-					metric.Labels)
-				counterVec.WithLabelValues(labelValue...).Set(values[i])
-				counterVec.Collect(ch)
-			}
-
 		}
 
 		// GC Stats


### PR DESCRIPTION
Hello.

With reference to #87, I added metrics the following.

Please review.

```
# HELP elasticsearch_indices_query_cache_cache_size Query cache cache size
# TYPE elasticsearch_indices_query_cache_cache_size gauge
elasticsearch_indices_query_cache_cache_size{cluster="test"} 28869
# HELP elasticsearch_indices_query_cache_cache_count Query cache cache count
# TYPE elasticsearch_indices_query_cache_cache_count gauge
elasticsearch_indices_query_cache_cache_count{cluster="test"} 28925
# HELP elasticsearch_indices_query_cache_total Query cache total count
# TYPE elasticsearch_indices_query_cache_total counter
elasticsearch_indices_query_cache_total{cluster="test"} 4.916801e+06
# HELP elasticsearch_indices_query_cache_count Query cache count
# TYPE elasticsearch_indices_query_cache_count counter
elasticsearch_indices_query_cache_count{category="hit",cluster="test"} 1.958521e+06
elasticsearch_indices_query_cache_count{category="miss",cluster="test"} 2.95828e+06
# HELP elasticsearch_indices_request_cache_count Request cache count
# TYPE elasticsearch_indices_request_cache_count counter
elasticsearch_indices_request_cache_count{category="hit",cluster="test"} 75749
elasticsearch_indices_request_cache_count{category="miss",cluster="test"} 65144
```