### PR TITLE
Implementing metrics for jvm pool memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ elasticsearch_exporter --help
 | elasticsearch_jvm_memory_committed_bytes                   | gauge     | 2            | JVM memory currently committed by area
 | elasticsearch_jvm_memory_max_bytes                         | gauge     | 1            | JVM memory max
 | elasticsearch_jvm_memory_used_bytes                        | gauge     | 2            | JVM memory currently used by area
+| elasticsearch_jvm_memory_pool_used_bytes                   | gauge     | 3            | JVM memory currently used by pool
+| elasticsearch_jvm_memory_pool_max_bytes                    | counter   | 3            | JVM memory max by pool
+| elasticsearch_jvm_memory_pool_peak_used_bytes              | counter   | 3            | JVM memory peak used by pool
+| elasticsearch_jvm_memory_pool_peak_max_bytes               | counter   | 3            | JVM memory peak max by pool
 | elasticsearch_process_cpu_percent                          | gauge     | 1            | Percent CPU used by process
 | elasticsearch_process_cpu_time_seconds_sum                 | counter   | 3            | Process CPU time in seconds
 | elasticsearch_process_mem_resident_size_bytes              | gauge     | 1            | Resident memory in use by process in bytes

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -760,6 +760,174 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "used_bytes"),
+					"JVM memory currently used by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["young"].Used)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "young")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "max_bytes"),
+					"JVM memory max by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["young"].Max)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "young")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "peak_used_bytes"),
+					"JVM memory peak used by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["young"].PeakUsed)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "young")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "peak_max_bytes"),
+					"JVM memory peak max by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["young"].PeakMax)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "young")
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "used_bytes"),
+					"JVM memory currently used by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["survivor"].Used)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "survivor")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "max_bytes"),
+					"JVM memory max by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["survivor"].Max)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "survivor")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "peak_used_bytes"),
+					"JVM memory peak used by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["survivor"].PeakUsed)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "survivor")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "peak_max_bytes"),
+					"JVM memory peak max by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["survivor"].PeakMax)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "survivor")
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "used_bytes"),
+					"JVM memory currently used by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["old"].Used)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "old")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "max_bytes"),
+					"JVM memory max by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["old"].Max)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "old")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "peak_used_bytes"),
+					"JVM memory peak used by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["old"].PeakUsed)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "old")
+				},
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_memory_pool", "peak_max_bytes"),
+					"JVM memory peak max by pool",
+					append(defaultNodeLabels, "pool"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Mem.Pools["old"].PeakMax)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "old")
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "process", "cpu_percent"),
 					"Percent CPU used by process",
 					defaultNodeLabels, nil,

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -59,11 +59,19 @@ type NodeStatsJVMBufferPoolResponse struct {
 }
 
 type NodeStatsJVMMemResponse struct {
-	HeapCommitted    int64 `json:"heap_committed_in_bytes"`
-	HeapUsed         int64 `json:"heap_used_in_bytes"`
-	HeapMax          int64 `json:"heap_max_in_bytes"`
-	NonHeapCommitted int64 `json:"non_heap_committed_in_bytes"`
-	NonHeapUsed      int64 `json:"non_heap_used_in_bytes"`
+	HeapCommitted    int64                                  `json:"heap_committed_in_bytes"`
+	HeapUsed         int64                                  `json:"heap_used_in_bytes"`
+	HeapMax          int64                                  `json:"heap_max_in_bytes"`
+	NonHeapCommitted int64                                  `json:"non_heap_committed_in_bytes"`
+	NonHeapUsed      int64                                  `json:"non_heap_used_in_bytes"`
+	Pools            map[string]NodeStatsJVMMemPoolResponse `json:"pools"`
+}
+
+type NodeStatsJVMMemPoolResponse struct {
+	Used     int64 `json:"used_in_bytes"`
+	Max      int64 `json:"max_in_bytes"`
+	PeakUsed int64 `json:"peak_used_in_bytes"`
+	PeakMax  int64 `json:"peak_max_in_bytes"`
 }
 
 type NodeStatsNetworkResponse struct {


### PR DESCRIPTION
This PR exposes the metrics retrieved from the `/_nodes/_local/stats` endpoint under `nodes-><id>->jvm->memory->pools`.

I was uncertain of the naming regarding `elasticsearch_jvm_memory_pool_max_bytes` and `elasticsearch_jvm_memory_pool_peak_max_bytes`. Perhaps it should be named `elasticsearch_jvm_memory_pool_max_used_bytes` with the `_used` suffix but since it's exposed from the ES endpoint as simply `max` I chose to keep that naming.