### PR TITLE
Add support for shard-level document count

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ elasticsearch_exporter --help
 | es.uri                | Address (host and port) of the Elasticsearch node we should connect to. This could be a local node (`localhost:9200`, for instance), or the address of a remote Elasticsearch server. When basic auth is needed, specify as: `<proto>://<user>:<password>@<host>:<port>`. E.G., `http://admin:pass@localhost:9200`.
 | es.all                | If true, query stats for all nodes in the cluster, rather than just the node we connect to.
 | es.indices            | If true, query stats for all indices in the cluster.
+| es.shards             | If true, query stats for all indices in the cluster, including shard-level stats (implies `es.indices=true`).
 | es.timeout            | Timeout for trying to get stats from Elasticsearch. (ex: 20s) |
 | es.ca                 | Path to PEM file that contains trusted CAs for the Elasticsearch connection.
 | es.client-private-key | Path to PEM file that contains the private key for client auth when connecting to Elasticsearch.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ elasticsearch_exporter --help
 | elasticsearch_indices_docs                                 | gauge     | 1            | Count of documents on this node
 | elasticsearch_indices_docs_deleted                         | gauge     | 1            | Count of deleted documents on this node
 | elasticsearch_indices_docs_primary                         | gauge     |              | Count of documents with only primary shards on all nodes
-| elasticsearch_indices_docs_shard                           | gauge     | 3            | Count of documents on each shard
 | elasticsearch_indices_fielddata_evictions                  | counter   | 1            | Evictions from field data
 | elasticsearch_indices_fielddata_memory_size_bytes          | gauge     | 1            | Field data cache memory usage in bytes
 | elasticsearch_indices_filter_cache_evictions               | counter   | 1            | Evictions from filter cache
@@ -113,6 +112,8 @@ elasticsearch_exporter --help
 | elasticsearch_indices_search_query_total                   | counter   | 1            | Total number of queries
 | elasticsearch_indices_segments_count                       | gauge     | 1            | Count of index segments on this node
 | elasticsearch_indices_segments_memory_bytes                | gauge     | 1            | Current memory size of segments in bytes
+| elasticsearch_indices_shards_docs                          | gauge     | 3            | Count of documents on this shard
+| elasticsearch_indices_shards_docs_deleted                  | gauge     | 3            | Count of deleted documents on each shard
 | elasticsearch_indices_store_size_bytes                     | gauge     | 1            | Current size of stored index data in bytes
 | elasticsearch_indices_store_size_bytes_primary             | gauge     |              | Current size of stored index data in bytes with only primary shards on all nodes
 | elasticsearch_indices_store_size_bytes_total               | gauge     |              | Current size of stored index data in bytes with all shards on all nodes

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ elasticsearch_exporter --help
 | elasticsearch_indices_docs                                 | gauge     | 1            | Count of documents on this node
 | elasticsearch_indices_docs_deleted                         | gauge     | 1            | Count of deleted documents on this node
 | elasticsearch_indices_docs_primary                         | gauge     |              | Count of documents with only primary shards on all nodes
+| elasticsearch_indices_docs_shard                           | gauge     | 3            | Count of documents on each shard
 | elasticsearch_indices_fielddata_evictions                  | counter   | 1            | Evictions from field data
 | elasticsearch_indices_fielddata_memory_size_bytes          | gauge     | 1            | Field data cache memory usage in bytes
 | elasticsearch_indices_filter_cache_evictions               | counter   | 1            | Evictions from filter cache

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -26,11 +26,11 @@ type indexMetric struct {
 }
 
 type shardMetric struct {
-	Opts   prometheus.GaugeOpts
-	Type   prometheus.ValueType
-	Desc   *prometheus.Desc
-	Value  func(data IndexStatsIndexShardsDetailResponse) float64
-	Labels []string
+	Opts        prometheus.GaugeOpts
+	Type        prometheus.ValueType
+	Desc        *prometheus.Desc
+	Value       func(data IndexStatsIndexShardsDetailResponse) float64
+	Labels      []string
 	LabelValues func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse) prometheus.Labels
 }
 
@@ -371,13 +371,13 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL) *Indices {
 		shardMetrics: []*shardMetric{
 			{
 				Opts: prometheus.GaugeOpts{
-					Namespace:namespace,
-					Subsystem: "indices",
-					Name: "docs_shard",
+					Namespace:   namespace,
+					Subsystem:   "indices",
+					Name:        "docs_shard",
 					ConstLabels: nil,
-					Help: "Count of documents per shard",
+					Help:        "Count of documents per shard",
 				},
-				Value: func (data IndexStatsIndexShardsDetailResponse) float64 {
+				Value: func(data IndexStatsIndexShardsDetailResponse) float64 {
 					return float64(data.Docs.Count)
 				},
 				Labels: []string{"index", "shard", "node"},

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -373,12 +373,28 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL) *Indices {
 				Opts: prometheus.GaugeOpts{
 					Namespace:   namespace,
 					Subsystem:   "indices",
-					Name:        "docs_shard",
+					Name:        "shards_docs",
 					ConstLabels: nil,
-					Help:        "Count of documents per shard",
+					Help:        "Count of documents on this shard",
 				},
 				Value: func(data IndexStatsIndexShardsDetailResponse) float64 {
 					return float64(data.Docs.Count)
+				},
+				Labels: []string{"index", "shard", "node"},
+				LabelValues: func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse) prometheus.Labels {
+					return prometheus.Labels{"index": indexName, "shard": shardName, "node": data.Routing.Node}
+				},
+			},
+			{
+				Opts: prometheus.GaugeOpts{
+					Namespace:   namespace,
+					Subsystem:   "indices",
+					Name:        "shards_docs_deleted",
+					ConstLabels: nil,
+					Help:        "Count of deleted documents on this shard",
+				},
+				Value: func(data IndexStatsIndexShardsDetailResponse) float64 {
+					return float64(data.Docs.Deleted)
 				},
 				Labels: []string{"index", "shard", "node"},
 				LabelValues: func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse) prometheus.Labels {

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -38,6 +38,7 @@ type Indices struct {
 	logger log.Logger
 	client *http.Client
 	url    *url.URL
+	shards bool
 
 	up                prometheus.Gauge
 	totalScrapes      prometheus.Counter
@@ -47,11 +48,12 @@ type Indices struct {
 	shardMetrics []*shardMetric
 }
 
-func NewIndices(logger log.Logger, client *http.Client, url *url.URL) *Indices {
+func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards bool) *Indices {
 	return &Indices{
 		logger: logger,
 		client: client,
 		url:    url,
+		shards: shards,
 
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, "index_stats", "up"),
@@ -414,14 +416,16 @@ func (i *Indices) Describe(ch chan<- *prometheus.Desc) {
 	ch <- i.jsonParseFailures.Desc()
 }
 
-func (c *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
+func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 	var isr indexStatsResponse
 
-	u := *c.url
+	u := *i.url
 	u.Path = "/_all/_stats"
-	u.RawQuery = "level=shards"
+	if i.shards {
+		u.RawQuery = "level=shards"
+	}
 
-	res, err := c.client.Get(u.String())
+	res, err := i.client.Get(u.String())
 	if err != nil {
 		return isr, fmt.Errorf("failed to get index stats from %s://%s:%s%s: %s",
 			u.Scheme, u.Hostname(), u.Port(), u.Path, err)
@@ -432,7 +436,7 @@ func (c *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(&isr); err != nil {
-		c.jsonParseFailures.Inc()
+		i.jsonParseFailures.Inc()
 		return isr, err
 	}
 
@@ -470,14 +474,16 @@ func (i *Indices) Collect(ch chan<- prometheus.Metric) {
 			)
 
 		}
-		for _, metric := range i.shardMetrics {
-			gaugeVec := prometheus.NewGaugeVec(metric.Opts, metric.Labels)
-			for shardNumber, shards := range indexStats.Shards {
-				for _, shard := range shards {
-					gaugeVec.With(metric.LabelValues(indexName, shardNumber, shard)).Set(metric.Value(shard))
+		if i.shards {
+			for _, metric := range i.shardMetrics {
+				gaugeVec := prometheus.NewGaugeVec(metric.Opts, metric.Labels)
+				for shardNumber, shards := range indexStats.Shards {
+					for _, shard := range shards {
+						gaugeVec.With(metric.LabelValues(indexName, shardNumber, shard)).Set(metric.Value(shard))
+					}
 				}
+				gaugeVec.Collect(ch)
 			}
-			gaugeVec.Collect(ch)
 		}
 	}
 }

--- a/collector/indices_response.go
+++ b/collector/indices_response.go
@@ -14,8 +14,8 @@ type IndexStatsShardsResponse struct {
 }
 
 type IndexStatsIndexResponse struct {
-	Primaries IndexStatsIndexDetailResponse `json:"primaries"`
-	Total     IndexStatsIndexDetailResponse `json:"total"`
+	Primaries IndexStatsIndexDetailResponse                    `json:"primaries"`
+	Total     IndexStatsIndexDetailResponse                    `json:"total"`
 	Shards    map[string][]IndexStatsIndexShardsDetailResponse `json:"shards"`
 }
 

--- a/collector/indices_response.go
+++ b/collector/indices_response.go
@@ -16,6 +16,7 @@ type IndexStatsShardsResponse struct {
 type IndexStatsIndexResponse struct {
 	Primaries IndexStatsIndexDetailResponse `json:"primaries"`
 	Total     IndexStatsIndexDetailResponse `json:"total"`
+	Shards    map[string][]IndexStatsIndexShardsDetailResponse `json:"shards"`
 }
 
 type IndexStatsIndexDetailResponse struct {
@@ -35,6 +36,16 @@ type IndexStatsIndexDetailResponse struct {
 	Translog     IndexStatsIndexTranslogResponse     `json:"translog"`
 	RequestCache IndexStatsIndexRequestCacheResponse `json:"request_cache"`
 	Recovery     IndexStatsIndexRecoveryResponse     `json:"recovery"`
+}
+
+type IndexStatsIndexShardsDetailResponse struct {
+	*IndexStatsIndexDetailResponse
+	Routing IndexStatsIndexRoutingResponse `json:"routing"`
+}
+
+type IndexStatsIndexRoutingResponse struct {
+	Node    string `json:"node"`
+	Primary bool   `json:"primary"`
 }
 
 type IndexStatsIndexDocsResponse struct {

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -35,7 +35,7 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false)
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 		esTimeout          = flag.Duration("es.timeout", 5*time.Second, "Timeout for trying to get stats from Elasticsearch.")
 		esAllNodes         = flag.Bool("es.all", false, "Export stats for all nodes in the cluster.")
 		esExportIndices    = flag.Bool("es.indices", false, "Export stats for indices in the cluster.")
+		esExportShards     = flag.Bool("es.shards", false, "Export stats for shards in the cluster (implies es.indices=true).")
 		esCA               = flag.String("es.ca", "", "Path to PEM file that conains trusted CAs for the Elasticsearch connection.")
 		esClientPrivateKey = flag.String("es.client-private-key", "", "Path to PEM file that conains the private key for client auth when connecting to Elasticsearch.")
 		esClientCert       = flag.String("es.client-cert", "", "Path to PEM file that conains the corresponding cert for the private key to connect to Elasticsearch.")
@@ -67,8 +68,8 @@ func main() {
 	prometheus.MustRegister(versionMetric)
 	prometheus.MustRegister(collector.NewClusterHealth(logger, httpClient, esURL))
 	prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes))
-	if *esExportIndices {
-		prometheus.MustRegister(collector.NewIndices(logger, httpClient, esURL))
+	if *esExportIndices || *esExportShards {
+		prometheus.MustRegister(collector.NewIndices(logger, httpClient, esURL, *esExportShards))
 	}
 
 	http.Handle(*metricsPath, prometheus.Handler())

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 		esTimeout            = flag.Duration("es.timeout", 5*time.Second, "Timeout for trying to get stats from Elasticsearch.")
 		esAllNodes           = flag.Bool("es.all", false, "Export stats for all nodes in the cluster.")
 		esExportIndices      = flag.Bool("es.indices", false, "Export stats for indices in the cluster.")
-    esExportShards       = flag.Bool("es.shards", false, "Export stats for shards in the cluster (implies es.indices=true).")
+		esExportShards       = flag.Bool("es.shards", false, "Export stats for shards in the cluster (implies es.indices=true).")
 		esCA                 = flag.String("es.ca", "", "Path to PEM file that contains trusted CAs for the Elasticsearch connection.")
 		esClientPrivateKey   = flag.String("es.client-private-key", "", "Path to PEM file that conains the private key for client auth when connecting to Elasticsearch.")
 		esClientCert         = flag.String("es.client-cert", "", "Path to PEM file that conains the corresponding cert for the private key to connect to Elasticsearch.")


### PR DESCRIPTION
In cases where replicas get out of sync with the primary, it would be extremely useful to be able to track differences in the count of document on shard-level over time. 