### PR TITLE
Add node-level current merge metrics

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -688,6 +688,18 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 				Labels: defaultNodeLabelValues,
 			},
 			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices_merges", "current"),
+					"Current merges",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.Merges.Current)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices_merges", "docs_total"),


### PR DESCRIPTION
Hey folks, I was using this metric to debug an issue recently and thought it might be helpful for others. This adds a gauge to track current number of merges on a per-node basis.