### PR TITLE
Add OS CPU percent metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ elasticsearch_exporter --help
 | elasticsearch_jvm_memory_pool_max_bytes                    | counter   | 3            | JVM memory max by pool
 | elasticsearch_jvm_memory_pool_peak_used_bytes              | counter   | 3            | JVM memory peak used by pool
 | elasticsearch_jvm_memory_pool_peak_max_bytes               | counter   | 3            | JVM memory peak max by pool
+| elasticsearch_os_cpu_percent                               | gauge     | 1            | Percent CPU used by the OS
+| elasticsearch_os_load1                                     | gauge     | 1            | Shortterm load average
+| elasticsearch_os_load5                                     | gauge     | 1            | Midterm load average
+| elasticsearch_os_load15                                    | gauge     | 1            | Longterm load average
 | elasticsearch_process_cpu_percent                          | gauge     | 1            | Percent CPU used by process
 | elasticsearch_process_cpu_time_seconds_sum                 | counter   | 3            | Process CPU time in seconds
 | elasticsearch_process_mem_resident_size_bytes              | gauge     | 1            | Resident memory in use by process in bytes

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -184,17 +184,17 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 				Labels: defaultNodeLabelValues,
 			},
 			{
-                Type: prometheus.GaugeValue,
-                Desc: prometheus.NewDesc(
-                    prometheus.BuildFQName(namespace, "os", "cpu_percent"),
-                    "Percent CPU used by OS",
-                    defaultNodeLabels, nil,
-                ),
-                Value: func(node NodeStatsNodeResponse) float64 {
-                    return float64(node.OS.CPU.Percent)
-                },
-                Labels: defaultNodeLabelValues,
-            },
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "os", "cpu_percent"),
+					"Percent CPU used by OS",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.OS.CPU.Percent)
+				},
+				Labels: defaultNodeLabelValues,
+			},
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -184,6 +184,18 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 				Labels: defaultNodeLabelValues,
 			},
 			{
+                Type: prometheus.GaugeValue,
+                Desc: prometheus.NewDesc(
+                    prometheus.BuildFQName(namespace, "os", "cpu_percent"),
+                    "Percent CPU used by OS",
+                    defaultNodeLabels, nil,
+                ),
+                Value: func(node NodeStatsNodeResponse) float64 {
+                    return float64(node.OS.CPU.Percent)
+                },
+                Labels: defaultNodeLabelValues,
+            },
+			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices", "fielddata_memory_size_bytes"),

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -237,6 +237,7 @@ type NodeStatsOSCPUResponse struct {
 	Idle    int64                      `json:"idle"`
 	Steal   int64                      `json:"stolen"`
 	LoadAvg NodeStatsOSCPULoadResponse `json:"load_average"`
+	Percent int64                      `json:"percent"`
 }
 
 type NodeStatsOSCPULoadResponse struct {


### PR DESCRIPTION
We're using an elastic.co hosted cluster and noticed that the `cpu_percent` metric was reporting as `0` consistently (coming from the `process` object. This PR adds the `cpu_percent` metric for the `OS` object.

I've also added the existing `elasticsearch_os_load1`, `elasticsearch_os_load5`, and `elasticsearch_os_load15` metrics to the `README`.

Let me know if I'm on the right track with this or if tests need to accompany it.