### PR TITLE
Ensure SSL verification flag is set in tls.Config

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -8,6 +8,12 @@ import (
 )
 
 func createTLSConfig(pemFile, pemCertFile, pemPrivateKeyFile string, insecureSkipVerify bool) *tls.Config {
+	if insecureSkipVerify {
+		// pem settings are irrelevent if we're skipping verification anyway
+		return &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
 	if len(pemFile) <= 0 {
 		return nil
 	}


### PR DESCRIPTION
Fixes #136, so that InsecureSkipVerify is still set when CA/client SSL certs aren't specified on the command line