### PR TITLE
Use `sum/count` instead of just `sum` to catch elasticsearch_cluster_health_number_of_nodes

### DIFF
--- a/examples/grafana/dashboard.json
+++ b/examples/grafana/dashboard.json
@@ -71,7 +71,7 @@
           },
           "targets": [
             {
-              "expr": "sum(elasticsearch_cluster_health_number_of_nodes{cluster=~\"$cluster\"})",
+              "expr": "sum(elasticsearch_cluster_health_number_of_nodes{cluster=~\"$cluster\"})/count(elasticsearch_cluster_health_number_of_nodes{cluster=~\"$cluster\"})",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "",


### PR DESCRIPTION
If you have a exporter in each ES node and just `sum` all `elasticsearch_cluster_health_number_of_nodes` you will get a square of your cluster size... :grimacing: 