### PR TITLE
add count of indices in cluster

### DIFF
--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -35,7 +35,7 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, "test-cluster", false)
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/main.go
+++ b/main.go
@@ -83,7 +83,9 @@ func main() {
 			os.Exit(1)
 		}
 		defer resp.Body.Close()
-		d := new(bodyData)
+		d := &struct {
+			ClusterName string `json:"cluster_name"`
+		}{}
 		if err := json.NewDecoder(resp.Body).Decode(d); err != nil {
 			level.Error(logger).Log(
 				"msg", "error decoding cluster data",
@@ -108,10 +110,6 @@ func main() {
 			"err", err,
 		)
 	}
-}
-
-type bodyData struct {
-	ClusterName string `json:"cluster_name"`
 }
 
 // IndexHandler returns a http handler with the correct metricsPath


### PR DESCRIPTION
Realised that `/_all/_stats` contains _all_ indices in the cluster, ref #131.