### PR TITLE
Add elastic max file descriptors metric

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -1046,6 +1046,18 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 				Labels: defaultNodeLabelValues,
 			},
 			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "process", "max_files_descriptors"),
+					"Max file descriptors",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Process.MaxFD)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "process", "cpu_time_seconds_sum"),


### PR DESCRIPTION
This metric would be useful to have when looking at elastic search file descriptors.