### PR TITLE
Support for reverse proxies

### DIFF
--- a/collector/cluster_health.go
+++ b/collector/cluster_health.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -224,7 +225,7 @@ func (c *ClusterHealth) fetchAndDecodeClusterHealth() (clusterHealthResponse, er
 	var chr clusterHealthResponse
 
 	u := *c.url
-	u.Path = "/_cluster/health"
+	u.Path = path.Join(u.Path, "/_cluster/health")
 	res, err := c.client.Get(u.String())
 	if err != nil {
 		return chr, fmt.Errorf("failed to get cluster health from %s://%s:%s%s: %s",

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -456,7 +457,7 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 	var isr indexStatsResponse
 
 	u := *i.url
-	u.Path = "/_all/_stats"
+	u.Path = path.Join(u.Path, "/_all/_stats")
 	if i.shards {
 		u.RawQuery = "level=shards"
 	}

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -1359,9 +1360,11 @@ func (c *Nodes) fetchAndDecodeNodeStats() (nodeStatsResponse, error) {
 	var nsr nodeStatsResponse
 
 	u := *c.url
-	u.Path = "/_nodes/_local/stats"
+
 	if c.all {
-		u.Path = "/_nodes/stats"
+		u.Path = path.Join(u.Path, "/_nodes/stats")
+	} else {
+		u.Path = path.Join(u.Path, "/_nodes/_local/stats")
 	}
 
 	res, err := c.client.Get(u.String())


### PR DESCRIPTION
Currently, both `cluster_health.go` and `nodes.go` are overwriting the path provided by the `es.uri` flag, assuming that it will always be empty. However, this assumption is not always correct: In some cases it's useful to access the Elasticsearch endpoint behind a reverse proxy (e.g., Kubernetes) for testing purposes. This fix adds support for this scenario.