### PR TITLE
Add option to query a specific node from cluster

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -128,6 +128,7 @@ type Nodes struct {
 	client *http.Client
 	url    *url.URL
 	all    bool
+	node   string
 
 	up                              prometheus.Gauge
 	totalScrapes, jsonParseFailures prometheus.Counter
@@ -141,12 +142,13 @@ type Nodes struct {
 }
 
 // NewNodes defines Nodes Prometheus metrics
-func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *Nodes {
+func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, node string) *Nodes {
 	return &Nodes{
 		logger: logger,
 		client: client,
 		url:    url,
 		all:    all,
+		node:   node,
 
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, "node_stats", "up"),
@@ -1444,7 +1446,7 @@ func (c *Nodes) fetchAndDecodeNodeStats() (nodeStatsResponse, error) {
 	if c.all {
 		u.Path = path.Join(u.Path, "/_nodes/stats")
 	} else {
-		u.Path = path.Join(u.Path, "/_nodes/_local/stats")
+		u.Path = path.Join(u.Path, "_nodes", c.node, "stats")
 	}
 
 	res, err := c.client.Get(u.String())

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -44,7 +44,7 @@ func TestNodesStats(t *testing.T) {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
 			u.User = url.UserPassword("elastic", "changeme")
-			c := NewNodes(log.NewNopLogger(), http.DefaultClient, u, true)
+			c := NewNodes(log.NewNopLogger(), http.DefaultClient, u, true, "_local")
 			nsr, err := c.fetchAndDecodeNodeStats()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode node stats: %s", err)

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 		esURI                = flag.String("es.uri", "http://localhost:9200", "HTTP API address of an Elasticsearch node.")
 		esTimeout            = flag.Duration("es.timeout", 5*time.Second, "Timeout for trying to get stats from Elasticsearch.")
 		esAllNodes           = flag.Bool("es.all", false, "Export stats for all nodes in the cluster.")
+		esNode               = flag.String("es.node", "_local", "Node's name of which metrics should be exposed.")
 		esExportIndices      = flag.Bool("es.indices", false, "Export stats for indices in the cluster.")
 		esExportShards       = flag.Bool("es.shards", false, "Export stats for shards in the cluster (implies es.indices=true).")
 		esCA                 = flag.String("es.ca", "", "Path to PEM file that contains trusted CAs for the Elasticsearch connection.")
@@ -69,7 +70,7 @@ func main() {
 	versionMetric := version.NewCollector(Name)
 	prometheus.MustRegister(versionMetric)
 	prometheus.MustRegister(collector.NewClusterHealth(logger, httpClient, esURL))
-	prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes))
+	prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes, *esNode))
 	if *esExportIndices || *esExportShards {
 		prometheus.MustRegister(collector.NewIndices(logger, httpClient, esURL, *esExportShards))
 	}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 		metricsPath          = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		esURI                = flag.String("es.uri", "http://localhost:9200", "HTTP API address of an Elasticsearch node.")
 		esTimeout            = flag.Duration("es.timeout", 5*time.Second, "Timeout for trying to get stats from Elasticsearch.")
-		esAllNodes           = flag.Bool("es.all", false, "Export stats for all nodes in the cluster.")
+		esAllNodes           = flag.Bool("es.all", false, "Export stats for all nodes in the cluster. If used, this flag will override the flag es.node.")
 		esNode               = flag.String("es.node", "_local", "Node's name of which metrics should be exposed.")
 		esExportIndices      = flag.Bool("es.indices", false, "Export stats for indices in the cluster.")
 		esExportShards       = flag.Bool("es.shards", false, "Export stats for shards in the cluster (implies es.indices=true).")


### PR DESCRIPTION
With the current options of the elastic exporter we had trouble gather metrics for some nodes of the cluster that hadn't the http api enabled.  This made gathering metrics for this nodes only possible by activating the option to gather all the cluster metrics. This, for us, was not the desired option.

To solve this problem we used the option of the elastic api to pass as an argument the name of the node and receive the metrics for that node.

With this change we can query our nodes with the exporter and receive the metrics for the nodes of the cluster that don't have the http api installed.