### PR TITLE
Include cluster name in -es.indices or -es.shards output.

### DIFF
--- a/collector/cluster_health.go
+++ b/collector/cluster_health.go
@@ -220,6 +220,20 @@ func (c *ClusterHealth) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.jsonParseFailures.Desc()
 }
 
+func (c *ClusterHealth) FetchClusterName() (string, error) {
+	clusterHealthResponse, err := c.fetchAndDecodeClusterHealth()
+	if err != nil {
+		c.up.Set(0)
+		level.Warn(c.logger).Log(
+			"msg", "failed to fetch and decode cluster health",
+			"err", err,
+		)
+		return "", nil
+	}
+
+	return clusterHealthResponse.ClusterName, nil
+}
+
 func (c *ClusterHealth) fetchAndDecodeClusterHealth() (clusterHealthResponse, error) {
 	var chr clusterHealthResponse
 

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	defaultIndexLabels      = []string{"index"}
-	defaultIndexLabelValues = func(indexName string) []string {
-		return []string{indexName}
+	defaultIndexLabels      = []string{"index", "cluster"}
+	defaultIndexLabelValues = func(indexName string, clusterName string) []string {
+		return []string{indexName, clusterName}
 	}
 )
 
@@ -22,7 +22,7 @@ type indexMetric struct {
 	Type   prometheus.ValueType
 	Desc   *prometheus.Desc
 	Value  func(indexStats IndexStatsIndexResponse) float64
-	Labels func(indexName string) []string
+	Labels func(indexName string, clusterName string) []string
 }
 
 type shardMetric struct {
@@ -31,14 +31,16 @@ type shardMetric struct {
 	Desc        *prometheus.Desc
 	Value       func(data IndexStatsIndexShardsDetailResponse) float64
 	Labels      []string
-	LabelValues func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse) prometheus.Labels
+	LabelValues func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse, clusterName string) prometheus.Labels
 }
 
 type Indices struct {
-	logger log.Logger
-	client *http.Client
-	url    *url.URL
-	shards bool
+	logger           log.Logger
+	client           *http.Client
+	url              *url.URL
+	shards           bool
+	fetchClusterName func() string
+	clusterName      string // This clusterName is sticky--once set, it does not change.
 
 	up                prometheus.Gauge
 	totalScrapes      prometheus.Counter
@@ -48,12 +50,14 @@ type Indices struct {
 	shardMetrics []*shardMetric
 }
 
-func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards bool) *Indices {
+func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards bool, fetchClusterName func() string) *Indices {
 	return &Indices{
-		logger: logger,
-		client: client,
-		url:    url,
-		shards: shards,
+		logger:           logger,
+		client:           client,
+		url:              url,
+		shards:           shards,
+		fetchClusterName: fetchClusterName,
+		clusterName:      "",
 
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, "index_stats", "up"),
@@ -418,9 +422,9 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 				Value: func(data IndexStatsIndexShardsDetailResponse) float64 {
 					return float64(data.Docs.Count)
 				},
-				Labels: []string{"index", "shard", "node"},
-				LabelValues: func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse) prometheus.Labels {
-					return prometheus.Labels{"index": indexName, "shard": shardName, "node": data.Routing.Node}
+				Labels: []string{"index", "shard", "node", "cluster"},
+				LabelValues: func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse, clusterName string) prometheus.Labels {
+					return prometheus.Labels{"index": indexName, "shard": shardName, "node": data.Routing.Node, "cluster": clusterName}
 				},
 			},
 			{
@@ -434,9 +438,9 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 				Value: func(data IndexStatsIndexShardsDetailResponse) float64 {
 					return float64(data.Docs.Deleted)
 				},
-				Labels: []string{"index", "shard", "node"},
-				LabelValues: func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse) prometheus.Labels {
-					return prometheus.Labels{"index": indexName, "shard": shardName, "node": data.Routing.Node}
+				Labels: []string{"index", "shard", "node", "cluster"},
+				LabelValues: func(indexName string, shardName string, data IndexStatsIndexShardsDetailResponse, clusterName string) prometheus.Labels {
+					return prometheus.Labels{"index": indexName, "shard": shardName, "node": data.Routing.Node, "cluster": clusterName}
 				},
 			},
 		},
@@ -487,6 +491,10 @@ func (i *Indices) Collect(ch chan<- prometheus.Metric) {
 		ch <- i.jsonParseFailures
 	}()
 
+	if i.clusterName == "" {
+		i.clusterName = i.fetchClusterName()
+	}
+
 	// indices
 	indexStatsResponse, err := i.fetchAndDecodeIndexStats()
 	if err != nil {
@@ -506,7 +514,7 @@ func (i *Indices) Collect(ch chan<- prometheus.Metric) {
 				metric.Desc,
 				metric.Type,
 				metric.Value(indexStats),
-				metric.Labels(indexName)...,
+				metric.Labels(indexName, i.clusterName)...,
 			)
 
 		}
@@ -515,7 +523,7 @@ func (i *Indices) Collect(ch chan<- prometheus.Metric) {
 				gaugeVec := prometheus.NewGaugeVec(metric.Opts, metric.Labels)
 				for shardNumber, shards := range indexStats.Shards {
 					for _, shard := range shards {
-						gaugeVec.With(metric.LabelValues(indexName, shardNumber, shard)).Set(metric.Value(shard))
+						gaugeVec.With(metric.LabelValues(indexName, shardNumber, shard, i.clusterName)).Set(metric.Value(shard))
 					}
 				}
 				gaugeVec.Collect(ch)

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -35,7 +35,7 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false, func() string { return "testKluster" })
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)
@@ -49,6 +49,9 @@ func TestIndices(t *testing.T) {
 		}
 		if stats.Indices["foo_1"].Total.Store.SizeInBytes == 0 {
 			t.Errorf("Wrong number of total store size in bytes")
+		}
+		if i.fetchClusterName() != "testKluster" {
+			t.Errorf("Cluster name not persisted")
 		}
 	}
 }


### PR DESCRIPTION
Cluster name is set once the cluster can be connected to, and is not
refreshed after that. Fixes #135 for my own purposes by adding the most important label: `cluster`.