### PR TITLE
Add filesystem IO metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,103 +58,108 @@ elasticsearch_exporter --help
 
 ### Metrics
 
-|Name                                                        |Type       |Cardinality   |Help
-|----                                                        |----       |-----------   |----
-| elasticsearch_breakers_estimated_size_bytes                | gauge     | 4            | Estimated size in bytes of breaker
-| elasticsearch_breakers_limit_size_bytes                    | gauge     | 4            | Limit size in bytes for breaker
-| elasticsearch_breakers_tripped                             | counter   | 4            | tripped for breaker
-| elasticsearch_cluster_health_active_primary_shards         | gauge     | 1            | The number of primary shards in your cluster. This is an aggregate total across all indices.
-| elasticsearch_cluster_health_active_shards                 | gauge     | 1            | Aggregate total of all shards across all indices, which includes replica shards.
-| elasticsearch_cluster_health_delayed_unassigned_shards     | gauge     | 1            | Shards delayed to reduce reallocation overhead
-| elasticsearch_cluster_health_initializing_shards           | gauge     | 1            | Count of shards that are being freshly created.
-| elasticsearch_cluster_health_number_of_data_nodes          | gauge     | 1            | Number of data nodes in the cluster.
-| elasticsearch_cluster_health_number_of_in_flight_fetch     | gauge     | 1            | The number of ongoing shard info requests.
-| elasticsearch_cluster_health_number_of_nodes               | gauge     | 1            | Number of nodes in the cluster.
-| elasticsearch_cluster_health_number_of_pending_tasks       | gauge     | 1            | Cluster level changes which have not yet been executed
-| elasticsearch_cluster_health_relocating_shards             | gauge     | 1            | The number of shards that are currently moving from one node to another node.
-| elasticsearch_cluster_health_status                        | gauge     | 3            | Whether all primary and replica shards are allocated.
-| elasticsearch_cluster_health_timed_out                     | gauge     | 1            | Number of cluster health checks timed out
-| elasticsearch_cluster_health_unassigned_shards             | gauge     | 1            | The number of shards that exist in the cluster state, but cannot be found in the cluster itself.
-| elasticsearch_filesystem_data_available_bytes              | gauge     | 1            | Available space on block device in bytes
-| elasticsearch_filesystem_data_free_bytes                   | gauge     | 1            | Free space on block device in bytes
-| elasticsearch_filesystem_data_size_bytes                   | gauge     | 1            | Size of block device in bytes
-| elasticsearch_indices_docs                                 | gauge     | 1            | Count of documents on this node
-| elasticsearch_indices_docs_deleted                         | gauge     | 1            | Count of deleted documents on this node
-| elasticsearch_indices_docs_primary                         | gauge     |              | Count of documents with only primary shards on all nodes
-| elasticsearch_indices_fielddata_evictions                  | counter   | 1            | Evictions from field data
-| elasticsearch_indices_fielddata_memory_size_bytes          | gauge     | 1            | Field data cache memory usage in bytes
-| elasticsearch_indices_filter_cache_evictions               | counter   | 1            | Evictions from filter cache
-| elasticsearch_indices_filter_cache_memory_size_bytes       | gauge     | 1            | Filter cache memory usage in bytes
-| elasticsearch_indices_flush_time_seconds                   | counter   | 1            | Cumulative flush time in seconds
-| elasticsearch_indices_flush_total                          | counter   | 1            | Total flushes
-| elasticsearch_indices_get_exists_time_seconds              | counter   | 1            | Total time get exists in seconds
-| elasticsearch_indices_get_exists_total                     | counter   | 1            | Total get exists operations
-| elasticsearch_indices_get_missing_time_seconds             | counter   | 1            | Total time of get missing in seconds
-| elasticsearch_indices_get_missing_total                    | counter   | 1            | Total get missing
-| elasticsearch_indices_get_time_seconds                     | counter   | 1            | Total get time in seconds
-| elasticsearch_indices_get_total                            | counter   | 1            | Total get
-| elasticsearch_indices_indexing_delete_time_seconds_total   | counter   | 1            | Total time indexing delete in seconds
-| elasticsearch_indices_indexing_delete_total                | counter   | 1            | Total indexing deletes
-| elasticsearch_indices_indexing_index_time_seconds_total    | counter   | 1            | Cumulative index time in seconds
-| elasticsearch_indices_indexing_index_total                 | counter   | 1            | Total index calls
-| elasticsearch_indices_merges_docs_total                    | counter   | 1            | Cumulative docs merged
-| elasticsearch_indices_merges_total                         | counter   | 1            | Total merges
-| elasticsearch_indices_merges_total_size_bytes_total        | counter   | 1            | Total merge size in bytes
-| elasticsearch_indices_merges_total_time_seconds_total      | counter   | 1            | Total time spent merging in seconds
-| elasticsearch_indices_query_cache_cache_count              | gauge     | 1            | Count of query cache
-| elasticsearch_indices_query_cache_cache_size               | gauge     | 1            | Size of query cache
-| elasticsearch_indices_query_cache_count                    | counter   | 2            | Count of query cache hit/miss
-| elasticsearch_indices_query_cache_evictions                | counter   | 1            | Evictions from query cache
-| elasticsearch_indices_query_cache_memory_size_bytes        | gauge     | 1            | Query cache memory usage in bytes
-| elasticsearch_indices_query_cache_total                    | counter   | 1            | Size of query cache total
-| elasticsearch_indices_refresh_time_seconds_total           | counter   | 1            | Total refreshes
-| elasticsearch_indices_refresh_total                        | counter   | 1            | Total time spent refreshing in seconds
-| elasticsearch_indices_request_cache_count                  | counter   | 2            | Count of request cache hit/miss
-| elasticsearch_indices_request_cache_evictions              | counter   | 1            | Evictions from request cache
-| elasticsearch_indices_request_cache_memory_size_bytes      | gauge     | 1            | Request cache memory usage in bytes
-| elasticsearch_indices_search_fetch_time_seconds            | counter   | 1            | Total search fetch time in seconds
-| elasticsearch_indices_search_fetch_total                   | counter   | 1            | Total number of fetches
-| elasticsearch_indices_search_query_time_seconds            | counter   | 1            | Total search query time in seconds
-| elasticsearch_indices_search_query_total                   | counter   | 1            | Total number of queries
-| elasticsearch_indices_segments_count                       | gauge     | 1            | Count of index segments on this node
-| elasticsearch_indices_segments_memory_bytes                | gauge     | 1            | Current memory size of segments in bytes
-| elasticsearch_indices_shards_docs                          | gauge     | 3            | Count of documents on this shard
-| elasticsearch_indices_shards_docs_deleted                  | gauge     | 3            | Count of deleted documents on each shard
-| elasticsearch_indices_store_size_bytes                     | gauge     | 1            | Current size of stored index data in bytes
-| elasticsearch_indices_store_size_bytes_primary             | gauge     |              | Current size of stored index data in bytes with only primary shards on all nodes
-| elasticsearch_indices_store_size_bytes_total               | gauge     |              | Current size of stored index data in bytes with all shards on all nodes
-| elasticsearch_indices_store_throttle_time_seconds_total    | counter   | 1            | Throttle time for index store in seconds
-| elasticsearch_indices_translog_operations                  | counter   | 1            | Total translog operations
-| elasticsearch_indices_translog_size_in_bytes               | counter   | 1            | Total translog size in bytes
-| elasticsearch_jvm_gc_collection_seconds_count              | counter   | 2            | Count of JVM GC runs
-| elasticsearch_jvm_gc_collection_seconds_sum                | counter   | 2            | GC run time in seconds
-| elasticsearch_jvm_memory_committed_bytes                   | gauge     | 2            | JVM memory currently committed by area
-| elasticsearch_jvm_memory_max_bytes                         | gauge     | 1            | JVM memory max
-| elasticsearch_jvm_memory_used_bytes                        | gauge     | 2            | JVM memory currently used by area
-| elasticsearch_jvm_memory_pool_used_bytes                   | gauge     | 3            | JVM memory currently used by pool
-| elasticsearch_jvm_memory_pool_max_bytes                    | counter   | 3            | JVM memory max by pool
-| elasticsearch_jvm_memory_pool_peak_used_bytes              | counter   | 3            | JVM memory peak used by pool
-| elasticsearch_jvm_memory_pool_peak_max_bytes               | counter   | 3            | JVM memory peak max by pool
-| elasticsearch_os_cpu_percent                               | gauge     | 1            | Percent CPU used by the OS
-| elasticsearch_os_load1                                     | gauge     | 1            | Shortterm load average
-| elasticsearch_os_load5                                     | gauge     | 1            | Midterm load average
-| elasticsearch_os_load15                                    | gauge     | 1            | Longterm load average
-| elasticsearch_process_cpu_percent                          | gauge     | 1            | Percent CPU used by process
-| elasticsearch_process_cpu_time_seconds_sum                 | counter   | 3            | Process CPU time in seconds
-| elasticsearch_process_mem_resident_size_bytes              | gauge     | 1            | Resident memory in use by process in bytes
-| elasticsearch_process_mem_share_size_bytes                 | gauge     | 1            | Shared memory in use by process in bytes
-| elasticsearch_process_mem_virtual_size_bytes               | gauge     | 1            | Total virtual memory used in bytes
-| elasticsearch_process_open_files_count                     | gauge     | 1            | Open file descriptors
-| elasticsearch_thread_pool_active_count                     | gauge     | 14           | Thread Pool threads active
-| elasticsearch_thread_pool_completed_count                  | counter   | 14           | Thread Pool operations completed
-| elasticsearch_thread_pool_largest_count                    | gauge     | 14           | Thread Pool largest threads count
-| elasticsearch_thread_pool_queue_count                      | gauge     | 14           | Thread Pool operations queued
-| elasticsearch_thread_pool_rejected_count                   | counter   | 14           | Thread Pool operations rejected
-| elasticsearch_thread_pool_threads_count                    | gauge     | 14           | Thread Pool current threads count
-| elasticsearch_transport_rx_packets_total                   | counter   | 1            | Count of packets received
-| elasticsearch_transport_rx_size_bytes_total                | counter   | 1            | Total number of bytes received
-| elasticsearch_transport_tx_packets_total                   | counter   | 1            | Count of packets sent
-| elasticsearch_transport_tx_size_bytes_total                | counter   | 1            | Total number of bytes sent
+|Name                                                               |Type       |Cardinality   |Help
+|----                                                               |----       |-----------   |----
+| elasticsearch_breakers_estimated_size_bytes                       | gauge     | 4            | Estimated size in bytes of breaker
+| elasticsearch_breakers_limit_size_bytes                           | gauge     | 4            | Limit size in bytes for breaker
+| elasticsearch_breakers_tripped                                    | counter   | 4            | tripped for breaker
+| elasticsearch_cluster_health_active_primary_shards                | gauge     | 1            | The number of primary shards in your cluster. This is an aggregate total across all indices.
+| elasticsearch_cluster_health_active_shards                        | gauge     | 1            | Aggregate total of all shards across all indices, which includes replica shards.
+| elasticsearch_cluster_health_delayed_unassigned_shards            | gauge     | 1            | Shards delayed to reduce reallocation overhead
+| elasticsearch_cluster_health_initializing_shards                  | gauge     | 1            | Count of shards that are being freshly created.
+| elasticsearch_cluster_health_number_of_data_nodes                 | gauge     | 1            | Number of data nodes in the cluster.
+| elasticsearch_cluster_health_number_of_in_flight_fetch            | gauge     | 1            | The number of ongoing shard info requests.
+| elasticsearch_cluster_health_number_of_nodes                      | gauge     | 1            | Number of nodes in the cluster.
+| elasticsearch_cluster_health_number_of_pending_tasks              | gauge     | 1            | Cluster level changes which have not yet been executed
+| elasticsearch_cluster_health_relocating_shards                    | gauge     | 1            | The number of shards that are currently moving from one node to another node.
+| elasticsearch_cluster_health_status                               | gauge     | 3            | Whether all primary and replica shards are allocated.
+| elasticsearch_cluster_health_timed_out                            | gauge     | 1            | Number of cluster health checks timed out
+| elasticsearch_cluster_health_unassigned_shards                    | gauge     | 1            | The number of shards that exist in the cluster state, but cannot be found in the cluster itself.
+| elasticsearch_filesystem_data_available_bytes                     | gauge     | 1            | Available space on block device in bytes
+| elasticsearch_filesystem_data_free_bytes                          | gauge     | 1            | Free space on block device in bytes
+| elasticsearch_filesystem_data_size_bytes                          | gauge     | 1            | Size of block device in bytes
+| elasticsearch_filesystem_io_stats_device_operations_count         | gauge     | 1            | Count of disk operations
+| elasticsearch_filesystem_io_stats_device_read_operations_count    | gauge     | 1            | Count of disk read operations
+| elasticsearch_filesystem_io_stats_device_write_operations_count   | gauge     | 1            | Count of disk write operations
+| elasticsearch_filesystem_io_stats_device_read_size_kilobytes_sum  | gauge     | 1            | Total kilobytes read from disk
+| elasticsearch_filesystem_io_stats_device_write_size_kilobytes_sum | gauge     | 1            | Total kilobytes written to disk
+| elasticsearch_indices_docs                                        | gauge     | 1            | Count of documents on this node
+| elasticsearch_indices_docs_deleted                                | gauge     | 1            | Count of deleted documents on this node
+| elasticsearch_indices_docs_primary                                | gauge     |              | Count of documents with only primary shards on all nodes
+| elasticsearch_indices_fielddata_evictions                         | counter   | 1            | Evictions from field data
+| elasticsearch_indices_fielddata_memory_size_bytes                 | gauge     | 1            | Field data cache memory usage in bytes
+| elasticsearch_indices_filter_cache_evictions                      | counter   | 1            | Evictions from filter cache
+| elasticsearch_indices_filter_cache_memory_size_bytes              | gauge     | 1            | Filter cache memory usage in bytes
+| elasticsearch_indices_flush_time_seconds                          | counter   | 1            | Cumulative flush time in seconds
+| elasticsearch_indices_flush_total                                 | counter   | 1            | Total flushes
+| elasticsearch_indices_get_exists_time_seconds                     | counter   | 1            | Total time get exists in seconds
+| elasticsearch_indices_get_exists_total                            | counter   | 1            | Total get exists operations
+| elasticsearch_indices_get_missing_time_seconds                    | counter   | 1            | Total time of get missing in seconds
+| elasticsearch_indices_get_missing_total                           | counter   | 1            | Total get missing
+| elasticsearch_indices_get_time_seconds                            | counter   | 1            | Total get time in seconds
+| elasticsearch_indices_get_total                                   | counter   | 1            | Total get
+| elasticsearch_indices_indexing_delete_time_seconds_total          | counter   | 1            | Total time indexing delete in seconds
+| elasticsearch_indices_indexing_delete_total                       | counter   | 1            | Total indexing deletes
+| elasticsearch_indices_indexing_index_time_seconds_total           | counter   | 1            | Cumulative index time in seconds
+| elasticsearch_indices_indexing_index_total                        | counter   | 1            | Total index calls
+| elasticsearch_indices_merges_docs_total                           | counter   | 1            | Cumulative docs merged
+| elasticsearch_indices_merges_total                                | counter   | 1            | Total merges
+| elasticsearch_indices_merges_total_size_bytes_total               | counter   | 1            | Total merge size in bytes
+| elasticsearch_indices_merges_total_time_seconds_total             | counter   | 1            | Total time spent merging in seconds
+| elasticsearch_indices_query_cache_cache_count                     | gauge     | 1            | Count of query cache
+| elasticsearch_indices_query_cache_cache_size                      | gauge     | 1            | Size of query cache
+| elasticsearch_indices_query_cache_count                           | counter   | 2            | Count of query cache hit/miss
+| elasticsearch_indices_query_cache_evictions                       | counter   | 1            | Evictions from query cache
+| elasticsearch_indices_query_cache_memory_size_bytes               | gauge     | 1            | Query cache memory usage in bytes
+| elasticsearch_indices_query_cache_total                           | counter   | 1            | Size of query cache total
+| elasticsearch_indices_refresh_time_seconds_total                  | counter   | 1            | Total refreshes
+| elasticsearch_indices_refresh_total                               | counter   | 1            | Total time spent refreshing in seconds
+| elasticsearch_indices_request_cache_count                         | counter   | 2            | Count of request cache hit/miss
+| elasticsearch_indices_request_cache_evictions                     | counter   | 1            | Evictions from request cache
+| elasticsearch_indices_request_cache_memory_size_bytes             | gauge     | 1            | Request cache memory usage in bytes
+| elasticsearch_indices_search_fetch_time_seconds                   | counter   | 1            | Total search fetch time in seconds
+| elasticsearch_indices_search_fetch_total                          | counter   | 1            | Total number of fetches
+| elasticsearch_indices_search_query_time_seconds                   | counter   | 1            | Total search query time in seconds
+| elasticsearch_indices_search_query_total                          | counter   | 1            | Total number of queries
+| elasticsearch_indices_segments_count                              | gauge     | 1            | Count of index segments on this node
+| elasticsearch_indices_segments_memory_bytes                       | gauge     | 1            | Current memory size of segments in bytes
+| elasticsearch_indices_shards_docs                                 | gauge     | 3            | Count of documents on this shard
+| elasticsearch_indices_shards_docs_deleted                         | gauge     | 3            | Count of deleted documents on each shard
+| elasticsearch_indices_store_size_bytes                            | gauge     | 1            | Current size of stored index data in bytes
+| elasticsearch_indices_store_size_bytes_primary                    | gauge     |              | Current size of stored index data in bytes with only primary shards on all nodes
+| elasticsearch_indices_store_size_bytes_total                      | gauge     |              | Current size of stored index data in bytes with all shards on all nodes
+| elasticsearch_indices_store_throttle_time_seconds_total           | counter   | 1            | Throttle time for index store in seconds
+| elasticsearch_indices_translog_operations                         | counter   | 1            | Total translog operations
+| elasticsearch_indices_translog_size_in_bytes                      | counter   | 1            | Total translog size in bytes
+| elasticsearch_jvm_gc_collection_seconds_count                     | counter   | 2            | Count of JVM GC runs
+| elasticsearch_jvm_gc_collection_seconds_sum                       | counter   | 2            | GC run time in seconds
+| elasticsearch_jvm_memory_committed_bytes                          | gauge     | 2            | JVM memory currently committed by area
+| elasticsearch_jvm_memory_max_bytes                                | gauge     | 1            | JVM memory max
+| elasticsearch_jvm_memory_used_bytes                               | gauge     | 2            | JVM memory currently used by area
+| elasticsearch_jvm_memory_pool_used_bytes                          | gauge     | 3            | JVM memory currently used by pool
+| elasticsearch_jvm_memory_pool_max_bytes                           | counter   | 3            | JVM memory max by pool
+| elasticsearch_jvm_memory_pool_peak_used_bytes                     | counter   | 3            | JVM memory peak used by pool
+| elasticsearch_jvm_memory_pool_peak_max_bytes                      | counter   | 3            | JVM memory peak max by pool
+| elasticsearch_os_cpu_percent                                      | gauge     | 1            | Percent CPU used by the OS
+| elasticsearch_os_load1                                            | gauge     | 1            | Shortterm load average
+| elasticsearch_os_load5                                            | gauge     | 1            | Midterm load average
+| elasticsearch_os_load15                                           | gauge     | 1            | Longterm load average
+| elasticsearch_process_cpu_percent                                 | gauge     | 1            | Percent CPU used by process
+| elasticsearch_process_cpu_time_seconds_sum                        | counter   | 3            | Process CPU time in seconds
+| elasticsearch_process_mem_resident_size_bytes                     | gauge     | 1            | Resident memory in use by process in bytes
+| elasticsearch_process_mem_share_size_bytes                        | gauge     | 1            | Shared memory in use by process in bytes
+| elasticsearch_process_mem_virtual_size_bytes                      | gauge     | 1            | Total virtual memory used in bytes
+| elasticsearch_process_open_files_count                            | gauge     | 1            | Open file descriptors
+| elasticsearch_thread_pool_active_count                            | gauge     | 14           | Thread Pool threads active
+| elasticsearch_thread_pool_completed_count                         | counter   | 14           | Thread Pool operations completed
+| elasticsearch_thread_pool_largest_count                           | gauge     | 14           | Thread Pool largest threads count
+| elasticsearch_thread_pool_queue_count                             | gauge     | 14           | Thread Pool operations queued
+| elasticsearch_thread_pool_rejected_count                          | counter   | 14           | Thread Pool operations rejected
+| elasticsearch_thread_pool_threads_count                           | gauge     | 14           | Thread Pool current threads count
+| elasticsearch_transport_rx_packets_total                          | counter   | 1            | Count of packets received
+| elasticsearch_transport_rx_size_bytes_total                       | counter   | 1            | Total number of bytes received
+| elasticsearch_transport_tx_packets_total                          | counter   | 1            | Count of packets sent
+| elasticsearch_transport_tx_size_bytes_total                       | counter   | 1            | Total number of bytes sent
 
 ### Alerts & Recording Rules
 

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -275,21 +275,31 @@ type NodeStatsHTTPResponse struct {
 
 // NodeStatsFSResponse is a representation of a file system information, data path, free disk space, read/write stats
 type NodeStatsFSResponse struct {
-	Timestamp int64                     `json:"timestamp"`
-	Data      []NodeStatsFSDataResponse `json:"data"`
+	Timestamp int64                      `json:"timestamp"`
+	Data      []NodeStatsFSDataResponse  `json:"data"`
+	IOStats   NodeStatsFSIOStatsResponse `json:"io_stats"`
 }
 
 type NodeStatsFSDataResponse struct {
-	Path          string `json:"path"`
-	Mount         string `json:"mount"`
-	Device        string `json:"dev"`
-	Total         int64  `json:"total_in_bytes"`
-	Free          int64  `json:"free_in_bytes"`
-	Available     int64  `json:"available_in_bytes"`
-	DiskReads     int64  `json:"disk_reads"`
-	DiskWrites    int64  `json:"disk_writes"`
-	DiskReadSize  int64  `json:"disk_read_size_in_bytes"`
-	DiskWriteSize int64  `json:"disk_write_size_in_bytes"`
+	Path      string `json:"path"`
+	Mount     string `json:"mount"`
+	Device    string `json:"dev"`
+	Total     int64  `json:"total_in_bytes"`
+	Free      int64  `json:"free_in_bytes"`
+	Available int64  `json:"available_in_bytes"`
+}
+
+type NodeStatsFSIOStatsResponse struct {
+	Devices []NodeStatsFSIOStatsDeviceResponse `json:"devices"`
+}
+
+type NodeStatsFSIOStatsDeviceResponse struct {
+	DeviceName      string `json:"device_name"`
+	Operations      int64  `json:"operations"`
+	ReadOperations  int64  `json:"read_operations"`
+	WriteOperations int64  `json:"write_operations"`
+	ReadSize        int64  `json:"read_kilobytes"`
+	WriteSize       int64  `json:"write_kilobytes"`
 }
 
 // ClusterHealthResponse is a representation of a Elasticsearch Cluster Health


### PR DESCRIPTION
Filesystem IO metrics are in the elasticsearch nodestats output, but they were not being exported.

In addition to the new IO metrics, the filesystem `data` metrics have had their variables renamed to avoid confusion. In elastic <5 the only metric within the filesystem output of nodeStats  was `data`, which is why I assume the naming was less specific. In elastic >5 the filesystem output of nodeStats contains both `data` as well as `io_stats`.