### PR TITLE
Add gometalinter target to TravisCI

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,8 @@
+{
+  "Cyclo": 40,
+  "Deadline": "6m",
+  "EnableGC": true,
+  "Exclude": ["TLS InsecureSkipVerify set true.", "Potential file inclusion via variable"],
+  "Sort": ["linter", "severity", "path", "line"],
+  "Vendor": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.9.x
   - tip
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ go:
 script:
   - make style
   - make vet
-  - make test
+  - make gometalinter
   - make build
+  - make test
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
 
 GO    := GO15VENDOREXPERIMENT=1 go
 PROMU := $(GOPATH)/bin/promu
+GOLINTER                ?= $(GOPATH)/bin/gometalinter
 pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)
@@ -64,4 +65,14 @@ promu:
 	        GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
 	        $(GO) get -u github.com/prometheus/promu
 
-.PHONY: all style format build test vet tarball docker promu
+gometalinter: $(GOLINTER)
+	@echo ">> linting code"
+	@$(GOLINTER) --install > /dev/null
+	@$(GOLINTER) --config=./.gometalinter.json ./...
+
+$(GOPATH)/bin/gometalinter lint:
+	@GOOS=$(shell uname -s | tr A-Z a-z) \
+		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
+		$(GO) get -u github.com/alecthomas/gometalinter
+
+.PHONY: all style format build test vet tarball docker promu $(GOPATH)/bin/gometalinter lint


### PR DESCRIPTION
Hi @zwopir,

As told in #172, this add a Makefile target `gometalinter`, but run it only in TravisCI. This should save future related issues.

Thanks!