### PR TITLE
add buffer pool metrics

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -1003,6 +1003,34 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool) *N
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_buffer_pool", "used_bytes"),
+					"JVM buffer currently used",
+					append(defaultNodeLabels, "type"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.BufferPools["direct"].Used)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "direct")
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_buffer_pool", "used_bytes"),
+					"JVM buffer currently used",
+					append(defaultNodeLabels, "type"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.BufferPools["mapped"].Used)
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "mapped")
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "process", "cpu_percent"),
 					"Percent CPU used by process",
 					defaultNodeLabels, nil,


### PR DESCRIPTION
Hello.

I want to monitor buffer pool metrics.
Because Netty uses direct buffer.

We can get such metrics via Elasticsearch's `/_nodes/_local/stats` API.

```
"jvm": {
    "buffer_pools": {
        "direct": {
            "count": 40,
            "used_in_bytes": 135771544,
            "total_capacity_in_bytes": 135771543
        },
        "mapped": {
            "count": 0,
            "used_in_bytes": 0,
            "total_capacity_in_bytes": 0
        }
    },
    ...
},
...
```

The following metrics will be added by this PR.

```
# HELP elasticsearch_jvm_buffer_pool_used_bytes JVM buffer currently used
# TYPE elasticsearch_jvm_buffer_pool_used_bytes gauge
elasticsearch_jvm_buffer_pool_used_bytes{cluster="shopsearch-test",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="false",host="data001",name="data001",type="direct"} 1.35840543e+08
elasticsearch_jvm_buffer_pool_used_bytes{cluster="shopsearch-test",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="false",host="data001",name="data001",type="mapped"} 0
```
