### PR TITLE
Fixed createTLSConfig function

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -8,33 +8,28 @@ import (
 )
 
 func createTLSConfig(pemFile, pemCertFile, pemPrivateKeyFile string, insecureSkipVerify bool) *tls.Config {
+	tlsConfig := tls.Config{}
 	if insecureSkipVerify {
 		// pem settings are irrelevant if we're skipping verification anyway
-		return &tls.Config{
-			InsecureSkipVerify: true,
+		tlsConfig.InsecureSkipVerify = true
+	}
+	if len(pemFile) > 0 {
+		rootCerts, err := loadCertificatesFrom(pemFile)
+		if err != nil {
+			log.Fatalf("Couldn't load root certificate from %s. Got %s.", pemFile, err)
+			return nil
 		}
-	}
-	if len(pemFile) <= 0 {
-		return nil
-	}
-	rootCerts, err := loadCertificatesFrom(pemFile)
-	if err != nil {
-		log.Fatalf("Couldn't load root certificate from %s. Got %s.", pemFile, err)
+		tlsConfig.RootCAs = rootCerts
 	}
 	if len(pemCertFile) > 0 && len(pemPrivateKeyFile) > 0 {
 		clientPrivateKey, err := loadPrivateKeyFrom(pemCertFile, pemPrivateKeyFile)
 		if err != nil {
 			log.Fatalf("Couldn't setup client authentication. Got %s.", err)
+			return nil
 		}
-		return &tls.Config{
-			RootCAs:      rootCerts,
-			Certificates: []tls.Certificate{*clientPrivateKey},
-		}
+		tlsConfig.Certificates = []tls.Certificate{*clientPrivateKey}
 	}
-	return &tls.Config{
-		RootCAs:            rootCerts,
-		InsecureSkipVerify: insecureSkipVerify,
-	}
+	return &tlsConfig
 }
 
 func loadCertificatesFrom(pemFile string) (*x509.CertPool, error) {


### PR DESCRIPTION
Return full TLS configuration when ca, cert, key, and insecure flag are set. 
Related to this issue: https://github.com/justwatchcom/elasticsearch_exporter/issues/158 
Tested on elasticsearch:6.4.2 + search-guard-6:6.4.2-23.1 TLS plugin