### PR TITLE
Set proxy for http.Transport to autoevaluate from Enviroment

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func main() {
 		Timeout: *esTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
+			Proxy:           http.ProxyFromEnvironment,
 		},
 	}
 


### PR DESCRIPTION
My previous PR didn't used the official way to set proxy from Environment.
