### PR TITLE
expose name and date together with "index_name-date" 

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -13,9 +14,15 @@ import (
 )
 
 var (
-	defaultIndexLabels      = []string{"index"}
+	defaultIndexLabels      = []string{"index", "indexPrefix", "indexDate"}
 	defaultIndexLabelValues = func(indexName string) []string {
-		return []string{indexName}
+		indexDate := ""
+		indexFullName := strings.Split(indexName, "-")
+		indexPrefix := indexFullName[0]
+		if len(indexFullName) > 1 {
+			indexDate = indexFullName[1]
+		}
+		return []string{indexName, indexPrefix, indexDate}
 	}
 )
 


### PR DESCRIPTION
As we want to do some aggregations by name and date of index, we need to expose name and date together with the format "index_name-date".

example:
elasticsearch_index_stats_fielddata_evictions_total{index=".kibana-20180630",**indexDate="20180630"**,**indexPrefix=".kibana"**} 0