### PR TITLE
Allow Comma separated list of multiple ES servers

### DIFF
--- a/collector/cluster_health_test.go
+++ b/collector/cluster_health_test.go
@@ -30,7 +30,11 @@ func TestClusterHealth(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		c := NewClusterHealth(log.NewNopLogger(), http.DefaultClient, u)
+
+		urls := make([]*url.URL, 0)
+		urls = append(urls, u)
+
+		c := NewClusterHealth(log.NewNopLogger(), http.DefaultClient, urls)
 		chr, err := c.fetchAndDecodeClusterHealth()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode cluster health: %s", err)

--- a/collector/cluster_settings_test.go
+++ b/collector/cluster_settings_test.go
@@ -30,7 +30,11 @@ func TestClusterSettingsStats(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewClusterSettings(log.NewNopLogger(), http.DefaultClient, u)
+
+			urls := make([]*url.URL, 0)
+			urls = append(urls, u)
+
+			c := NewClusterSettings(log.NewNopLogger(), http.DefaultClient, urls)
 			nsr, err := c.fetchAndDecodeClusterSettingsStats()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode cluster settings stats: %s", err)

--- a/collector/http_probe.go
+++ b/collector/http_probe.go
@@ -1,0 +1,103 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// HTTPProbe is an empty struct
+type HTTPProbe struct {
+	urls            []*url.URL
+	timeoutDuration time.Duration
+	c               *http.Client
+	timeoutError    error
+}
+
+// NewHTTPProbe create a new HTTPProbe.
+func NewHTTPProbe(urls []*url.URL, c *http.Client) HTTPProbe {
+
+	uris := make([]string, 0)
+	for _, u := range urls {
+		uris = append(uris, u.String())
+	}
+
+	return HTTPProbe{
+		urls:            urls,
+		c:               c,
+		timeoutDuration: c.Timeout,
+		timeoutError:    fmt.Errorf("all uris unreachable, %s", strings.Join(uris, ",")),
+	}
+}
+
+// ProbeURL sends http head request to all urls and return the first url that responsed successfully.
+// Return err when non of the url is successful.
+func (p *HTTPProbe) ProbeURL() (*url.URL, error) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chans := make([]<-chan string, len(p.urls))
+
+	for _, u := range p.urls {
+		chans = append(chans, httpProbe(ctx, cancel, u.String()))
+	}
+
+	if p.timeoutDuration > 0 {
+		timeout := make(chan string, 1)
+		go func() {
+			<-time.After(p.timeoutDuration)
+			cancel()
+			timeout <- "timedout"
+		}()
+		chans = append(chans, timeout)
+	}
+
+	cases := make([]reflect.SelectCase, len(chans))
+
+	for i, ch := range chans {
+		cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)}
+	}
+
+	_, value, _ := reflect.Select(cases)
+
+	if value.String() == "timedout" {
+		return nil, p.timeoutError
+	}
+
+	v, err := url.Parse(value.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func httpProbe(ctx context.Context, cancel context.CancelFunc, uri string) <-chan string {
+
+	c1 := make(chan string, 1)
+
+	go func() {
+
+		req, err := http.NewRequest("HEAD", uri, nil)
+
+		if err != nil {
+			return
+		}
+
+		req = req.WithContext(ctx)
+
+		resp, err := http.DefaultClient.Do(req)
+
+		if err == nil && resp.StatusCode >= 200 && resp.StatusCode <= 399 {
+			cancel()
+			c1 <- uri
+		}
+	}()
+	return c1
+}

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -35,7 +35,10 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false)
+
+		urls := make([]*url.URL, 0)
+		urls = append(urls, u)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, urls, false)
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -44,7 +44,9 @@ func TestNodesStats(t *testing.T) {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
 			u.User = url.UserPassword("elastic", "changeme")
-			c := NewNodes(log.NewNopLogger(), http.DefaultClient, u, true, "_local")
+			urls := make([]*url.URL, 0)
+			urls = append(urls, u)
+			c := NewNodes(log.NewNopLogger(), http.DefaultClient, urls, true, "_local")
 			nsr, err := c.fetchAndDecodeNodeStats()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode node stats: %s", err)

--- a/collector/snapshots_test.go
+++ b/collector/snapshots_test.go
@@ -43,7 +43,9 @@ func TestSnapshots(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		s := NewSnapshots(log.NewNopLogger(), http.DefaultClient, u)
+		urls := make([]*url.URL, 0)
+		urls = append(urls, u)
+		s := NewSnapshots(log.NewNopLogger(), http.DefaultClient, urls)
 		stats, err := s.fetchAndDecodeSnapshotsStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode snapshots stats: %s", err)


### PR DESCRIPTION
Fix #117, Allow Comma separated list of multiple ES servers.

Allow Comma separated list of multiple ES servers for high availability scenarios. This allow running a single exporter container/process rather than N number of container/process per elasticsearch servers.

Before fetching stats from api, does http HEAD requests to list of es servers, pick the first url that responded, and use the healthly url to fetch stats from api.
