### PR TITLE
Indices Settings Extension (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ elasticsearch_exporter --help
 | es.all                | If true, query stats for all nodes in the cluster, rather than just the node we connect to.                             | false |
 | es.cluster_settings   | If true, query stats for cluster settings. | false |
 | es.indices            | If true, query stats for all indices in the cluster. | false |
+| es.indices_settings   | If true, query settings stats for all indices in the cluster. | false |
 | es.shards             | If true, query stats for all indices in the cluster, including shard-level stats (implies `es.indices=true`). | false |
 | es.snapshots          | If true, query stats for the cluster snapshots. | false |
 | es.timeout            | Timeout for trying to get stats from Elasticsearch. (ex: 20s) | 5s |
@@ -126,6 +127,7 @@ elasticsearch_exporter --help
 | elasticsearch_indices_search_query_total                   | counter   | 1            | Total number of queries
 | elasticsearch_indices_segments_count                       | gauge     | 1            | Count of index segments on this node
 | elasticsearch_indices_segments_memory_bytes                | gauge     | 1            | Current memory size of segments in bytes
+| elasticsearch_indices_settings_stats_read_only_indices     | counter   | 1            | Count of indices that have read_only_allow_delete=true
 | elasticsearch_indices_shards_docs                          | gauge     | 3            | Count of documents on this shard
 | elasticsearch_indices_shards_docs_deleted                  | gauge     | 3            | Count of deleted documents on each shard
 | elasticsearch_indices_store_size_bytes                     | gauge     | 1            | Current size of stored index data in bytes

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ elasticsearch_exporter --help
 | elasticsearch_indices_search_query_total                   | counter   | 1            | Total number of queries
 | elasticsearch_indices_segments_count                       | gauge     | 1            | Count of index segments on this node
 | elasticsearch_indices_segments_memory_bytes                | gauge     | 1            | Current memory size of segments in bytes
-| elasticsearch_indices_settings_stats_read_only_indices     | counter   | 1            | Count of indices that have read_only_allow_delete=true
+| elasticsearch_indices_settings_stats_read_only_indices     | gauge     | 1            | Count of indices that have read_only_allow_delete=true
 | elasticsearch_indices_shards_docs                          | gauge     | 3            | Count of documents on this shard
 | elasticsearch_indices_shards_docs_deleted                  | gauge     | 3            | Count of deleted documents on each shard
 | elasticsearch_indices_store_size_bytes                     | gauge     | 1            | Current size of stored index data in bytes

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -1,0 +1,131 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// IndicesSettings information struct
+type IndicesSettings struct {
+	logger log.Logger
+	client *http.Client
+	url    *url.URL
+
+	up                              prometheus.Gauge
+	readOnlyIndices                 prometheus.Gauge
+	totalScrapes, jsonParseFailures prometheus.Counter
+}
+
+// NewIndicesSettings defines Indices Settings Prometheus metrics
+func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *IndicesSettings {
+	return &IndicesSettings{
+		logger: logger,
+		client: client,
+		url:    url,
+
+		up: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: prometheus.BuildFQName(namespace, "indices_settings_stats", "up"),
+			Help: "Was the last scrape of the ElasticSearch Indices Settings endpoint successful.",
+		}),
+		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(namespace, "indices_settings_stats", "total_scrapes"),
+			Help: "Current total ElasticSearch Indices Settings scrapes.",
+		}),
+		readOnlyIndices: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: prometheus.BuildFQName(namespace, "indices_settings_stats", "read_only_indices"),
+			Help: "Current number of read only indices within cluster",
+		}),
+		jsonParseFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(namespace, "indices_settings_stats", "json_parse_failures"),
+			Help: "Number of errors while parsing JSON.",
+		}),
+	}
+}
+
+// Describe add Snapshots metrics descriptions
+func (cs *IndicesSettings) Describe(ch chan<- *prometheus.Desc) {
+	ch <- cs.up.Desc()
+	ch <- cs.totalScrapes.Desc()
+	ch <- cs.readOnlyIndices.Desc()
+	ch <- cs.jsonParseFailures.Desc()
+}
+
+func (cs *IndicesSettings) getAndParseURL(u *url.URL, data interface{}) error {
+	res, err := cs.client.Get(u.String())
+	if err != nil {
+		return fmt.Errorf("failed to get from %s://%s:%s%s: %s",
+			u.Scheme, u.Hostname(), u.Port(), u.Path, err)
+	}
+
+	defer func() {
+		err = res.Body.Close()
+		if err != nil {
+			_ = level.Warn(cs.logger).Log(
+				"msg", "failed to close http.Client",
+				"err", err,
+			)
+		}
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(data); err != nil {
+		cs.jsonParseFailures.Inc()
+		return err
+	}
+	return nil
+}
+
+func (cs *IndicesSettings) fetchAndDecodeIndicesSettings() (IndicesSettingsResponse, error) {
+
+	u := *cs.url
+	u.Path = path.Join(u.Path, "/_all/_settings")
+	var asr IndicesSettingsResponse
+	err := cs.getAndParseURL(&u, &asr)
+	if err != nil {
+		return asr, err
+	}
+
+	return asr, err
+}
+
+// Collect gets all indices settings metric values
+func (cs *IndicesSettings) Collect(ch chan<- prometheus.Metric) {
+
+	cs.totalScrapes.Inc()
+	defer func() {
+		ch <- cs.up
+		ch <- cs.totalScrapes
+		ch <- cs.jsonParseFailures
+		ch <- cs.readOnlyIndices
+	}()
+
+	asr, err := cs.fetchAndDecodeIndicesSettings()
+	if err != nil {
+		cs.readOnlyIndices.Set(0)
+		cs.up.Set(0)
+		_ = level.Warn(cs.logger).Log(
+			"msg", "failed to fetch and decode cluster settings stats",
+			"err", err,
+		)
+		return
+	}
+	cs.up.Set(1)
+
+	var c int
+	for _, value := range asr {
+		if value.Settings.IndexInfo.Blocks.ReadOnly == "true" {
+			c++
+		}
+	}
+	cs.readOnlyIndices.Set(float64(c))
+}

--- a/collector/indices_settings_response.go
+++ b/collector/indices_settings_response.go
@@ -1,0 +1,24 @@
+package collector
+
+// IndicesSettingsResponse is a representation of Elasticsearch Settings for each Index
+type IndicesSettingsResponse map[string]Index
+
+// Index defines the struct of the tree for the settings of each index
+type Index struct {
+	Settings Settings `json:"settings"`
+}
+
+// Settings defines current index settings
+type Settings struct {
+	IndexInfo IndexInfo `json:"index"`
+}
+
+// IndexInfo defines the blocks of the current index
+type IndexInfo struct {
+	Blocks Blocks `json:"blocks"`
+}
+
+// Blocks defines whether current index has read_only_allow_delete enabled
+type Blocks struct {
+	ReadOnly string `json:"read_only_allow_delete"`
+}

--- a/collector/indices_settings_test.go
+++ b/collector/indices_settings_test.go
@@ -1,0 +1,78 @@
+package collector
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+)
+
+func TestIndicesSettings(t *testing.T) {
+	// Testcases created using:
+	//  docker run -d -p 9200:9200 elasticsearch:VERSION
+	// curl -XPUT http://localhost:9200/twitter
+	// curl -XPUT http://localhost:9200/facebook
+	// curl -XPUT http://localhost:9200/instagram
+	// curl -XPUT http://localhost:9200/viber
+	// curl -XPUT http://localhost:9200/instagram/_settings --header "Content-Type: application/json" -d '
+	// {
+	//     "index": {
+	//         "blocks": {
+	//         "read_only_allow_delete": "true"
+	//         }
+	//     }
+	// }'
+	// curl -XPUT http://localhost:9200/twitter/_settings --header "Content-Type: application/json" -d '
+	// {
+	//     "index": {
+	//         "blocks": {
+	//         "read_only_allow_delete": "true"
+	//         }
+	//     }
+	// }'
+
+	// curl http://localhost:9200/_all/_settings
+
+	tcs := map[string]string{
+		"6.5.4": `{"viber":{"settings":{"index":{"creation_date":"1548066996192","number_of_shards":"5","number_of_replicas":"1","uuid":"kt2cGV-yQRaloESpqj2zsg","version":{"created":"6050499"},"provided_name":"viber"}}},"facebook":{"settings":{"index":{"creation_date":"1548066984670","number_of_shards":"5","number_of_replicas":"1","uuid":"jrU8OWQZQD--9v5eg0tjbg","version":{"created":"6050499"},"provided_name":"facebook"}}},"twitter":{"settings":{"index":{"number_of_shards":"5","blocks":{"read_only_allow_delete":"true"},"provided_name":"twitter","creation_date":"1548066697559","number_of_replicas":"1","uuid":"-sqtc4fVRrS2jHJCZ2hQ9Q","version":{"created":"6050499"}}}},"instagram":{"settings":{"index":{"number_of_shards":"5","blocks":{"read_only_allow_delete":"true"},"provided_name":"instagram","creation_date":"1548066991932","number_of_replicas":"1","uuid":"WeGWaxa_S3KrgE5SZHolTw","version":{"created":"6050499"}}}}}`,
+	}
+	for ver, out := range tcs {
+		for hn, handler := range map[string]http.Handler{
+			"plain": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, out)
+			}),
+		} {
+			ts := httptest.NewServer(handler)
+			defer ts.Close()
+
+			u, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatalf("Failed to parse URL: %s", err)
+			}
+			c := NewIndicesSettings(log.NewNopLogger(), http.DefaultClient, u)
+			nsr, err := c.fetchAndDecodeIndicesSettings()
+			if err != nil {
+				t.Fatalf("Failed to fetch or decode indices settings: %s", err)
+			}
+			t.Logf("[%s/%s] All Indices Settings Response: %+v", hn, ver, nsr)
+			// if nsr.Cluster.Routing.Allocation.Enabled != "ALL" {
+			// 	t.Errorf("Wrong setting for cluster routing allocation enabled")
+			// }
+			var counter int
+			for key, value := range nsr {
+				if value.Settings.IndexInfo.Blocks.ReadOnly == "true" {
+					counter++
+					if key != "instagram" && key != "twitter" {
+						t.Errorf("Wrong read_only index")
+					}
+				}
+			}
+			if counter != 2 {
+				t.Errorf("Wrong number of read_only indexes")
+			}
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 		esNode                  = flag.String("es.node", "_local", "Node's name of which metrics should be exposed.")
 		esExportIndices         = flag.Bool("es.indices", false, "Export stats for indices in the cluster.")
 		esExportClusterSettings = flag.Bool("es.cluster_settings", false, "Export stats for cluster settings.")
+		esExportIndicesSettings = flag.Bool("es.indices_settings", false, "Export stats for settings of all indices of the cluster.")
 		esExportShards          = flag.Bool("es.shards", false, "Export stats for shards in the cluster (implies es.indices=true).")
 		esExportSnapshots       = flag.Bool("es.snapshots", false, "Export stats for the cluster snapshots.")
 		esCA                    = flag.String("es.ca", "", "Path to PEM file that contains trusted Certificate Authorities for the Elasticsearch connection.")
@@ -82,6 +83,9 @@ func main() {
 	}
 	if *esExportClusterSettings {
 		prometheus.MustRegister(collector.NewClusterSettings(logger, httpClient, esURL))
+	}
+	if *esExportIndicesSettings {
+		prometheus.MustRegister(collector.NewIndicesSettings(logger, httpClient, esURL))
 	}
 	http.Handle(*metricsPath, prometheus.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
We created this extension of elasticsearch_exporter as we wanted to create a metric that will allow prometheus to scrape & alert us in case that an index becomes read_only.
This happens after we hit the high watermark that auto-modifies the indices that exist on the node with the problem to be read-only. ( Read More: cluster.routing.allocation.disk.watermark.flood_stage - https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html )