### PR TITLE
Change type for indices_query_cache_cache_count metric to counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ by replacing `.` with `_` and upper-casing the parameter name.
 | elasticsearch_indices_merges_total                                    | counter   | 1           | Total merges
 | elasticsearch_indices_merges_total_size_bytes_total                   | counter   | 1           | Total merge size in bytes
 | elasticsearch_indices_merges_total_time_seconds_total                 | counter   | 1           | Total time spent merging in seconds
-| elasticsearch_indices_query_cache_cache_count                         | counter   | 1           | Count of query cache
+| elasticsearch_indices_query_cache_cache_total                         | counter   | 1           | Count of query cache
 | elasticsearch_indices_query_cache_cache_size                          | gauge     | 1           | Size of query cache
 | elasticsearch_indices_query_cache_count                               | counter   | 2           | Count of query cache hit/miss
 | elasticsearch_indices_query_cache_evictions                           | counter   | 1           | Evictions from query cache

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ by replacing `.` with `_` and upper-casing the parameter name.
 | elasticsearch_indices_merges_total                                    | counter   | 1           | Total merges
 | elasticsearch_indices_merges_total_size_bytes_total                   | counter   | 1           | Total merge size in bytes
 | elasticsearch_indices_merges_total_time_seconds_total                 | counter   | 1           | Total time spent merging in seconds
-| elasticsearch_indices_query_cache_cache_count                         | gauge     | 1           | Count of query cache
+| elasticsearch_indices_query_cache_cache_count                         | counter   | 1           | Count of query cache
 | elasticsearch_indices_query_cache_cache_size                          | gauge     | 1           | Size of query cache
 | elasticsearch_indices_query_cache_count                               | counter   | 2           | Count of query cache hit/miss
 | elasticsearch_indices_query_cache_evictions                           | counter   | 1           | Evictions from query cache

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -396,7 +396,7 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 				Labels: defaultNodeLabelValues,
 			},
 			{
-				Type: prometheus.GaugeValue,
+				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices", "query_cache_cache_count"),
 					"Query cache cache count",

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -398,7 +398,7 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "indices", "query_cache_cache_count"),
+					prometheus.BuildFQName(namespace, "indices", "query_cache_cache_total"),
 					"Query cache cache count",
 					defaultNodeLabels, nil,
 				),


### PR DESCRIPTION
indices.query_cache.cache_count is the total number of cache entries that has been stored in the query cache, which should only increase or be reset.