### PR TITLE
Add indices_warmer_{time_seconds,total} metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ by replacing `.` with `_` and upper-casing the parameter name.
 | elasticsearch_indices_store_throttle_time_seconds_total               | counter   | 1           | Throttle time for index store in seconds
 | elasticsearch_indices_translog_operations                             | counter   | 1           | Total translog operations
 | elasticsearch_indices_translog_size_in_bytes                          | counter   | 1           | Total translog size in bytes
+| elasticsearch_indices_warmer_time_seconds                             | counter   | 1           | Total warmer time in seconds
+| elasticsearch_indices_warmer_total                                    | counter   | 1           | Total warmer count
 | elasticsearch_jvm_gc_collection_seconds_count                         | counter   | 2           | Count of JVM GC runs
 | elasticsearch_jvm_gc_collection_seconds_sum                           | counter   | 2           | GC run time in seconds
 | elasticsearch_jvm_memory_committed_bytes                              | gauge     | 2           | JVM memory currently committed by area

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ by replacing `.` with `_` and upper-casing the parameter name.
 | elasticsearch_indices_store_throttle_time_seconds_total               | counter   | 1           | Throttle time for index store in seconds
 | elasticsearch_indices_translog_operations                             | counter   | 1           | Total translog operations
 | elasticsearch_indices_translog_size_in_bytes                          | counter   | 1           | Total translog size in bytes
-| elasticsearch_indices_warmer_time_seconds                             | counter   | 1           | Total warmer time in seconds
+| elasticsearch_indices_warmer_time_seconds_total                       | counter   | 1           | Total warmer time in seconds
 | elasticsearch_indices_warmer_total                                    | counter   | 1           | Total warmer count
 | elasticsearch_jvm_gc_collection_seconds_count                         | counter   | 2           | Count of JVM GC runs
 | elasticsearch_jvm_gc_collection_seconds_sum                           | counter   | 2           | GC run time in seconds

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -866,6 +866,30 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "warmer_total"),
+					"Total warmer count",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.Warmer.Total)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "warmer_time_seconds"),
+					"Total warmer time in seconds",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.Warmer.TotalTime) / 1000
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices_indexing", "index_time_seconds_total"),
 					"Cumulative index time in seconds",
 					defaultNodeLabels, nil,

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -878,7 +878,7 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "indices", "warmer_time_seconds"),
+					prometheus.BuildFQName(namespace, "indices", "warmer_time_seconds_total"),
 					"Total warmer time in seconds",
 					defaultNodeLabels, nil,
 				),

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -131,6 +131,7 @@ type NodeStatsIndicesResponse struct {
 	QueryCache   NodeStatsIndicesCacheResponse `json:"query_cache"`
 	RequestCache NodeStatsIndicesCacheResponse `json:"request_cache"`
 	Flush        NodeStatsIndicesFlushResponse
+	Warmer       NodeStatsIndicesWarmerResponse
 	Segments     NodeStatsIndicesSegmentsResponse
 	Refresh      NodeStatsIndicesRefreshResponse
 	Translog     NodeStatsIndicesTranslogResponse
@@ -232,6 +233,12 @@ type NodeStatsIndicesSearchResponse struct {
 type NodeStatsIndicesFlushResponse struct {
 	Total int64 `json:"total"`
 	Time  int64 `json:"total_time_in_millis"`
+}
+
+// NodeStatsIndicesWarmerResponse defines node stats warmer information structure for indices
+type NodeStatsIndicesWarmerResponse struct {
+	Total     int64 `json:"total"`
+	TotalTime int64 `json:"total_time_in_millis"`
 }
 
 // NodeStatsIndicesCacheResponse defines node stats cache information structure for indices


### PR DESCRIPTION
They are the node-level versions of the index_stats_warmer_time_seconds_total and index_stats_warmer_total metrics.

