### PR TITLE
Add indices_segment_term_vectors_memory_bytes_{primary,total} metrics

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -275,7 +275,7 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "indices", "segment_term_vectors_memory_bytes_primary"),
+					prometheus.BuildFQName(namespace, "indices", "segment_term_vectors_memory_primary_bytes"),
 					"Current size of term vectors with only primary shards on all nodes in bytes",
 					indexLabels.keys(), nil,
 				),
@@ -287,7 +287,7 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "indices", "segment_term_vectors_memory_bytes_total"),
+					prometheus.BuildFQName(namespace, "indices", "segment_term_vectors_memory_total_bytes"),
 					"Current size of term vectors with all shards on all nodes in bytes",
 					indexLabels.keys(), nil,
 				),

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -275,6 +275,30 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "segment_term_vectors_memory_bytes_primary"),
+					"Current size of term vectors with only primary shards on all nodes in bytes",
+					indexLabels.keys(), nil,
+				),
+				Value: func(indexStats IndexStatsIndexResponse) float64 {
+					return float64(indexStats.Primaries.Segments.TermVectorsMemoryInBytes)
+				},
+				Labels: indexLabels,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "segment_term_vectors_memory_bytes_total"),
+					"Current size of term vectors with all shards on all nodes in bytes",
+					indexLabels.keys(), nil,
+				),
+				Value: func(indexStats IndexStatsIndexResponse) float64 {
+					return float64(indexStats.Total.Segments.TermVectorsMemoryInBytes)
+				},
+				Labels: indexLabels,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices", "segment_norms_memory_bytes_primary"),
 					"Current size of norms with only primary shards on all nodes in bytes",
 					indexLabels.keys(), nil,


### PR DESCRIPTION
The exported metrics will look like:

```
# HELP elasticsearch_indices_segment_term_vectors_memory_bytes_primary Current size of term vectors with only primary shards on all nodes in bytes
# TYPE elasticsearch_indices_segment_term_vectors_memory_bytes_primary gauge
elasticsearch_indices_segment_term_vectors_memory_bytes_primary{cluster="elasticsearch",index="foo"} 42
# HELP elasticsearch_indices_segment_term_vectors_memory_bytes_total Current size of term vectors with all shards on all nodes in bytes
# TYPE elasticsearch_indices_segment_term_vectors_memory_bytes_total gauge
elasticsearch_indices_segment_term_vectors_memory_bytes_total{cluster="elasticsearch",index="foo"} 42
```