### PR TITLE
Add indices_segments_{points,term_vectors,version_map}_memory_in_bytes metrics

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -840,6 +840,42 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 				Labels: defaultNodeLabelValues,
 			},
 			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "segments_term_vectors_memory_in_bytes"),
+					"Term vectors memory usage in bytes",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.Segments.TermVectorsMemory)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "segments_points_memory_in_bytes"),
+					"Point values memory usage in bytes",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.Segments.PointsMemory)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "segments_version_map_memory_in_bytes"),
+					"Version map memory usage in bytes",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.Segments.VersionMapMemory)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices", "flush_total"),

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -171,6 +171,9 @@ type NodeStatsIndicesSegmentsResponse struct {
 	StoredFieldsMemory int64 `json:"stored_fields_memory_in_bytes"`
 	FixedBitSet        int64 `json:"fixed_bit_set_memory_in_bytes"`
 	DocValuesMemory    int64 `json:"doc_values_memory_in_bytes"`
+	TermVectorsMemory  int64 `json:"term_vectors_memory_in_bytes"`
+	PointsMemory       int64 `json:"points_memory_in_bytes"`
+	VersionMapMemory   int64 `json:"version_map_memory_in_bytes"`
 }
 
 // NodeStatsIndicesStoreResponse defines node stats store information structure for indices


### PR DESCRIPTION
They are the node-level versions of the indices_segment_{points,version_map}_memory_bytes_total and indices_segment_term_vectors_memory_bytes_total (#252) metrics.

The exported metrics will look like:

```
# HELP elasticsearch_indices_segments_points_memory_in_bytes Point values memory usage in bytes
# TYPE elasticsearch_indices_segments_points_memory_in_bytes gauge
elasticsearch_indices_segments_points_memory_in_bytes{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="foo"} 42
# HELP elasticsearch_indices_segments_term_vectors_memory_in_bytes Term vectors memory usage in bytes
# TYPE elasticsearch_indices_segments_term_vectors_memory_in_bytes gauge
elasticsearch_indices_segments_term_vectors_memory_in_bytes{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="foo"} 42
# HELP elasticsearch_indices_segments_version_map_memory_in_bytes Version map memory usage in bytes
# TYPE elasticsearch_indices_segments_version_map_memory_in_bytes gauge
elasticsearch_indices_segments_version_map_memory_in_bytes{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="foo"} 42
```