### PR TITLE
K8s deployment improvements

### DIFF
--- a/examples/kubernetes/deployment.yml
+++ b/examples/kubernetes/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: p8s-elastic-exporter
@@ -9,6 +9,9 @@ spec:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
+  selector:
+    matchLabels:
+        app: p8s-elastic-exporter
   template:
     metadata:
       labels:

--- a/examples/kubernetes/deployment.yml
+++ b/examples/kubernetes/deployment.yml
@@ -25,6 +25,7 @@ spec:
         - /bin/elasticsearch_exporter
         - -es.uri=http://elasticsearch:9200
         - -es.all=true
+        - -web.listen-address=:9114
         image: justwatch/elasticsearch_exporter:1.0.2
         securityContext:
           capabilities:

--- a/examples/kubernetes/deployment.yml
+++ b/examples/kubernetes/deployment.yml
@@ -22,7 +22,7 @@ spec:
         - /bin/elasticsearch_exporter
         - -es.uri=http://elasticsearch:9200
         - -es.all=true
-        image: justwatch/elasticsearch_exporter:1.0.1
+        image: justwatch/elasticsearch_exporter:1.0.2
         securityContext:
           capabilities:
             drop:


### PR DESCRIPTION
- Update **docker image version** to the last stable version (v1.0.2)
- Replace deprecated **deployment apiVersion**
- Fix l**iveness/readiness probes errors**. It is fixed on the last RC (https://github.com/justwatchcom/elasticsearch_exporter/issues/165#issuecomment-487988161) but meanwhile...