### PR TITLE
Kubernetes manifest update for 1.1.0

### DIFF
--- a/examples/kubernetes/deployment.yml
+++ b/examples/kubernetes/deployment.yml
@@ -1,7 +1,8 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: p8s-elastic-exporter
+  name: elastic-exporter
 spec:
   replicas: 1
   strategy:
@@ -11,22 +12,18 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-        app: p8s-elastic-exporter
+      app: elastic-exporter
   template:
     metadata:
       labels:
-        app: p8s-elastic-exporter
+        app: elastic-exporter
     spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       containers:
       - command:
         - /bin/elasticsearch_exporter
-        - -es.uri=http://elasticsearch:9200
-        - -es.all=true
-        - -web.listen-address=:9114
-        image: justwatch/elasticsearch_exporter:1.0.2
+        - --es.uri=http://elasticsearch:9200
+        - --es.all
+        image: justwatch/elasticsearch_exporter:1.1.0
         securityContext:
           capabilities:
             drop:
@@ -47,16 +44,17 @@ spec:
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 9114
           initialDelaySeconds: 30
           timeoutSeconds: 10
-        name: p8s-elastic-exporter
+        name: elastic-exporter
         ports:
         - containerPort: 9114
+          name: http
         readinessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 9114
           initialDelaySeconds: 10
           timeoutSeconds: 10
@@ -68,3 +66,8 @@ spec:
             cpu: 25m
             memory: 64Mi
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 10000
+        runAsUser: 10000
+        fsGroup: 10000


### PR DESCRIPTION
- remove 'p8s-' prefix everywhere
- docker image to `1.1.0`
- update flags as short flag not allowed
- fix label indentation
- update readiness/liveliness checks to `/healthz`
- add port name `http`
- set high user/group ID

```
$ kubectl logs -f elastic-exporter-f658cf8dc-ct9dp
level=info ts=2019-08-11T03:09:13.131146062Z caller=clusterinfo.go:200 msg="triggering initial cluster info call"
level=info ts=2019-08-11T03:09:13.131372027Z caller=clusterinfo.go:169 msg="providing consumers with updated cluster info label"
level=error ts=2019-08-11T03:09:13.229194937Z caller=clusterinfo.go:253 msg="failed to get cluster info" err="Get http://elasticsearch:9200/: dial tcp: lookup elasticsearch on 10.1.0.10:53: no such host"
level=error ts=2019-08-11T03:09:13.229315897Z caller=clusterinfo.go:174 msg="failed to retrieve cluster info from ES" err="Get http://elasticsearch:9200/: dial tcp: lookup elasticsearch on 10.1.0.10:53: no such host"
level=info ts=2019-08-11T03:09:23.131581332Z caller=main.go:153 msg="initial cluster info call timed out"
level=info ts=2019-08-11T03:09:23.13198247Z caller=main.go:188 msg="starting elasticsearch_exporter" addr=:9114
```

```
$ kubectl exec -it elastic-exporter-f658cf8dc-ct9dp sh
/ $ id
uid=10000 gid=0(root) groups=10000
```