### PR TITLE
Fix spelling mistake in shards docs metric name

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -949,7 +949,7 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "indices", "shared_docs"),
+					prometheus.BuildFQName(namespace, "indices", "shards_docs"),
 					"Count of documents on this shard",
 					shardLabels.keys(), nil,
 				),


### PR DESCRIPTION
Updating the shards docs metric name to fix spelling mistake. Final metric name will be `elasticsearch_indices_shards_docs`.

Fixes https://github.com/justwatchcom/elasticsearch_exporter/issues/290