### PR TITLE
feat: latest snapshot timestamp metric

### DIFF
--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -186,7 +186,7 @@ func NewSnapshots(logger log.Logger, client *http.Client, url *url.URL) *Snapsho
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "snapshot_stats", "latest_snapshot_timestamp"),
+					prometheus.BuildFQName(namespace, "snapshot_stats", "latest_snapshot_seconds"),
 					"Timestamp of the latest SUCCESS or PARTIAL snapshot",
 					defaultSnapshotRepositoryLabels, nil,
 				),

--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -183,6 +183,28 @@ func NewSnapshots(logger log.Logger, client *http.Client, url *url.URL) *Snapsho
 				},
 				Labels: defaultSnapshotRepositoryLabelValues,
 			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "snapshot_stats", "latest_snapshot_timestamp"),
+					"Timestamp of the latest SUCCESS or PARTIAL snapshot",
+					defaultSnapshotRepositoryLabels, nil,
+				),
+				Value: func(snapshotsStats SnapshotStatsResponse) float64 {
+					var isAllowedState = func(s SnapshotStatDataResponse) bool {
+						return s.State == "SUCCESS" || s.State == "PARTIAL"
+					}
+
+					if len(snapshotsStats.Snapshots) > 0 && isAllowedState(snapshotsStats.Snapshots[0]) {
+						return float64(snapshotsStats.Snapshots[0].StartTimeInMillis / 1000)
+					}
+					if len(snapshotsStats.Snapshots) > 1 && isAllowedState(snapshotsStats.Snapshots[1]) {
+						return float64(snapshotsStats.Snapshots[1].StartTimeInMillis / 1000)
+					}
+					return 0
+				},
+				Labels: defaultSnapshotRepositoryLabelValues,
+			},
 		},
 	}
 }

--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -186,7 +186,7 @@ func NewSnapshots(logger log.Logger, client *http.Client, url *url.URL) *Snapsho
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "snapshot_stats", "latest_snapshot_seconds"),
+					prometheus.BuildFQName(namespace, "snapshot_stats", "latest_snapshot_timestamp_seconds"),
 					"Timestamp of the latest SUCCESS or PARTIAL snapshot",
 					defaultSnapshotRepositoryLabels, nil,
 				),

--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -191,15 +191,11 @@ func NewSnapshots(logger log.Logger, client *http.Client, url *url.URL) *Snapsho
 					defaultSnapshotRepositoryLabels, nil,
 				),
 				Value: func(snapshotsStats SnapshotStatsResponse) float64 {
-					var isAllowedState = func(s SnapshotStatDataResponse) bool {
-						return s.State == "SUCCESS" || s.State == "PARTIAL"
-					}
-
-					if len(snapshotsStats.Snapshots) > 0 && isAllowedState(snapshotsStats.Snapshots[0]) {
-						return float64(snapshotsStats.Snapshots[0].StartTimeInMillis / 1000)
-					}
-					if len(snapshotsStats.Snapshots) > 1 && isAllowedState(snapshotsStats.Snapshots[1]) {
-						return float64(snapshotsStats.Snapshots[1].StartTimeInMillis / 1000)
+					for i := len(snapshotsStats.Snapshots) - 1; i >= 0; i-- {
+						var snap = snapshotsStats.Snapshots[i]
+						if snap.State == "SUCCESS" || snap.State == "PARTIAL" {
+							return float64(snap.StartTimeInMillis / 1000)
+						}
 					}
 					return 0
 				},


### PR DESCRIPTION
added a new metric that reports the timestamp of the latest `SUCCESS`/`PARTIAL` snapshot.

This should make it easier to alert things like `X time since the last snapshot`, even more helpful when you have some sort of repository rotation (e.g. each month has a new repository / s3 bucket, and we keep up to 2 old repositories there).

with this metric the alert rule could be:

```
(time() - max without (repository) elasticsearch_snapshot_stats_latest_snapshot_timestamp) > X
```

Thanks!