### PR TITLE
Snapshot Repository Up Status

### DIFF
--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -47,6 +47,7 @@ type Snapshots struct {
 	totalScrapes, jsonParseFailures prometheus.Counter
 
 	snapshotMetrics   []*snapshotMetric
+	repositoryUp      repositoryMetric
 	repositoryMetrics []*repositoryMetric
 }
 
@@ -155,6 +156,22 @@ func NewSnapshots(logger log.Logger, client *http.Client, url *url.URL) *Snapsho
 				Labels: defaultSnapshotLabelValues,
 			},
 		},
+		repositoryUp: repositoryMetric{
+			Type: prometheus.GaugeValue,
+			Desc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, "snapshot_stats", "repository_up"),
+				"Whether or not the repo scrape was successful",
+				defaultSnapshotRepositoryLabels, nil,
+			),
+			Value: func(snapshotsStats SnapshotStatsResponse) float64 {
+				if snapshotsStats.Snapshots != nil {
+					return 1
+				} else {
+					return 0
+				}
+			},
+			Labels: defaultSnapshotRepositoryLabelValues,
+		},
 		repositoryMetrics: []*repositoryMetric{
 			{
 				Type: prometheus.GaugeValue,
@@ -257,10 +274,7 @@ func (s *Snapshots) fetchAndDecodeSnapshotsStats() (map[string]SnapshotStatsResp
 		u := *s.url
 		u.Path = path.Join(u.Path, "/_snapshot", repository, "/_all")
 		var ssr SnapshotStatsResponse
-		err := s.getAndParseURL(&u, &ssr)
-		if err != nil {
-			continue
-		}
+		_ = s.getAndParseURL(&u, &ssr)
 		mssr[repository] = ssr
 	}
 
@@ -290,6 +304,15 @@ func (s *Snapshots) Collect(ch chan<- prometheus.Metric) {
 
 	// Snapshots stats
 	for repositoryName, snapshotStats := range snapshotsStatsResp {
+		ch <- prometheus.MustNewConstMetric(
+			s.repositoryUp.Desc,
+			s.repositoryUp.Type,
+			s.repositoryUp.Value(snapshotStats),
+			s.repositoryUp.Labels(repositoryName)...,
+		)
+		if snapshotStats.Snapshots == nil {
+			continue
+		}
 		for _, metric := range s.repositoryMetrics {
 			ch <- prometheus.MustNewConstMetric(
 				metric.Desc,

--- a/collector/snapshots_test.go
+++ b/collector/snapshots_test.go
@@ -11,32 +11,26 @@ import (
 )
 
 func TestSnapshots(t *testing.T) {
-	// Testcases created using:
-	//  docker run -d -p 9200:9200 elasticsearch:VERSION-alpine  -Des.path.repo="/tmp" (1.7.6, 2.4.5)
-	//  docker run -d -p 9200:9200 elasticsearch:VERSION-alpine  -E path.repo="/tmp" (5.4.2)
-	//  curl -XPUT http://localhost:9200/foo_1/type1/1 -d '{"title":"abc","content":"hello"}'
-	//  curl -XPUT http://localhost:9200/foo_1/type1/2 -d '{"title":"def","content":"world"}'
-	//  curl -XPUT http://localhost:9200/foo_2/type1/1 -d '{"title":"abc001","content":"hello001"}'
-	//  curl -XPUT http://localhost:9200/foo_2/type1/2 -d '{"title":"def002","content":"world002"}'
-	//  curl -XPUT http://localhost:9200/foo_2/type1/3 -d '{"title":"def003","content":"world003"}'
-	//  curl -XPUT http://localhost:9200/_snapshot/test1 -d '{"type": "fs","settings":{"location": "/tmp/test1"}}'
-	//  curl -XPUT "http://localhost:9200/_snapshot/test1/snapshot_1?wait_for_completion=true"
-	//  curl http://localhost:9200/_snapshot/
-	//  curl http://localhost:9200/_snapshot/test1/_all
+	// Testcases created using $REPO/hack/snapshots_test_setup.sh
 
 	tcs := map[string][]string{
-		"1.7.6":        {`{"test1":{"type":"fs","settings":{"location":"/tmp/test1"}}}`, `{"snapshots":[{"snapshot":"snapshot_1","version_id":1070699,"version":"1.7.6","indices":["foo_1","foo_2"],"state":"SUCCESS","start_time":"2018-09-04T09:09:02.427Z","start_time_in_millis":1536052142427,"end_time":"2018-09-04T09:09:02.755Z","end_time_in_millis":1536052142755,"duration_in_millis":328,"failures":[],"shards":{"total":10,"failed":0,"successful":10}}]}`},
-		"2.4.5":        {`{"test1":{"type":"fs","settings":{"location":"/tmp/test1"}}}`, `{"snapshots":[{"snapshot":"snapshot_1","version_id":2040599,"version":"2.4.5","indices":["foo_2","foo_1"],"state":"SUCCESS","start_time":"2018-09-04T09:25:25.818Z","start_time_in_millis":1536053125818,"end_time":"2018-09-04T09:25:26.326Z","end_time_in_millis":1536053126326,"duration_in_millis":508,"failures":[],"shards":{"total":10,"failed":0,"successful":10}}]}`},
-		"5.4.2":        {`{"test1":{"type":"fs","settings":{"location":"/tmp/test1"}}}`, `{"snapshots":[{"snapshot":"snapshot_1","uuid":"VZ_c_kKISAW8rpcqiwSg0w","version_id":5040299,"version":"5.4.2","indices":["foo_2","foo_1"],"state":"SUCCESS","start_time":"2018-09-04T09:29:13.971Z","start_time_in_millis":1536053353971,"end_time":"2018-09-04T09:29:14.477Z","end_time_in_millis":1536053354477,"duration_in_millis":506,"failures":[],"shards":{"total":10,"failed":0,"successful":10}}]}`},
-		"5.4.2-failed": {`{"test1":{"type":"fs","settings":{"location":"/tmp/test1"}}}`, `{"snapshots":[{"snapshot":"snapshot_1","uuid":"VZ_c_kKISAW8rpcqiwSg0w","version_id":5040299,"version":"5.4.2","indices":["foo_2","foo_1"],"state":"SUCCESS","start_time":"2018-09-04T09:29:13.971Z","start_time_in_millis":1536053353971,"end_time":"2018-09-04T09:29:14.477Z","end_time_in_millis":1536053354477,"duration_in_millis":506,"failures":[{"index" : "index_name","index_uuid" : "index_name","shard_id" : 52,"reason" : "IndexShardSnapshotFailedException[error deleting index file [pending-index-5] during cleanup]; nested: NoSuchFileException[Blob [pending-index-5] does not exist]; ","node_id" : "pPm9jafyTjyMk0T5A101xA","status" : "INTERNAL_SERVER_ERROR"}],"shards":{"total":10,"failed":1,"successful":10}}]}`},
+		"5.6.16": {`{"succeed":{"type":"fs","settings":{"location":"/tmp/succeed"}},"fail":{"type":"fs","settings":{"location":"/tmp/fail"}}}`, `{"snapshots":[{"snapshot":"visible","uuid":"A1oKg_8PQBKzuRkQOOMG-w","version_id":5061699,"version":"5.6.16","indices":["foo_1","foo_2"],"state":"SUCCESS","start_time":"2020-04-23T12:18:26.872Z","start_time_in_millis":1587644306872,"end_time":"2020-04-23T12:18:27.052Z","end_time_in_millis":1587644307052,"duration_in_millis":180,"failures":[],"shards":{"total":2,"failed":0,"successful":2}}]}`, `{"error":{"root_cause":[{"type":"repository_exception","reason":"[fail] could not read repository data from index blob"}],"type":"repository_exception","reason":"[fail] could not read repository data from index blob","caused_by":{"type":"access_denied_exception","reason":"/tmp/fail"}},"status":500}`},
+		"6.8.8":  {`{"succeed":{"type":"fs","settings":{"location":"/tmp/succeed"}},"fail":{"type":"fs","settings":{"location":"/tmp/fail"}}}`, `{"snapshots":[{"snapshot":"visible","uuid":"-fCjIUhqTZG9GVlBZPEI3A","version_id":6080899,"version":"6.8.8","indices":["foo_1","foo_2"],"include_global_state":true,"state":"SUCCESS","start_time":"2020-04-23T12:18:35.681Z","start_time_in_millis":1587644315681,"end_time":"2020-04-23T12:18:35.925Z","end_time_in_millis":1587644315925,"duration_in_millis":244,"failures":[],"shards":{"total":2,"failed":0,"successful":2}}]}`, `{"error":{"root_cause":[{"type":"repository_exception","reason":"[fail] could not read repository data from index blob"}],"type":"repository_exception","reason":"[fail] could not read repository data from index blob","caused_by":{"type":"access_denied_exception","reason":"/tmp/fail"}},"status":500}`},
+		"7.6.2":  {`{"succeed":{"type":"fs","settings":{"location":"/tmp/succeed"}},"fail":{"type":"fs","settings":{"location":"/tmp/fail"}}}`, `{"snapshots":[{"snapshot":"visible","uuid":"ON95BFtaRjaQPaHEnhYdnA","version_id":7050299,"version":"7.5.2","indices":["foo_1","foo_2"],"include_global_state":true,"state":"SUCCESS","start_time":"2020-04-23T12:18:46.550Z","start_time_in_millis":1587644326550,"end_time":"2020-04-23T12:18:46.950Z","end_time_in_millis":1587644326950,"duration_in_millis":400,"failures":[],"shards":{"total":2,"failed":0,"successful":2}}]}`, `{"error":{"root_cause":[{"type":"repository_exception","reason":"[fail] Could not determine repository generation from root blobs"}],"type":"repository_exception","reason":"[fail] Could not determine repository generation from root blobs","caused_by":{"type":"access_denied_exception","reason":"/tmp/fail"}},"status":500}`},
 	}
 	for ver, out := range tcs {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.RequestURI == "/_snapshot" {
+			switch r.RequestURI {
+			case "/_snapshot":
 				fmt.Fprint(w, out[0])
 				return
+			case "/_snapshot/succeed/_all":
+				fmt.Fprint(w, out[1])
+				return
+			case "/_snapshot/fail/_all":
+				fmt.Fprint(w, out[2])
+				return
 			}
-			fmt.Fprint(w, out[1])
 		}))
 		defer ts.Close()
 
@@ -50,23 +44,30 @@ func TestSnapshots(t *testing.T) {
 			t.Fatalf("Failed to fetch or decode snapshots stats: %s", err)
 		}
 		t.Logf("[%s] Snapshots Response: %+v", ver, stats)
-		repositoryStats := stats["test1"]
-		snapshotStats := repositoryStats.Snapshots[0]
 
-		if len(snapshotStats.Indices) != 2 {
-			t.Errorf("Bad number of snapshot indices")
-		}
-		if len(snapshotStats.Failures) != int(snapshotStats.Shards.Failed) {
-			t.Errorf("Bad number of snapshot failures")
-		}
-		if snapshotStats.Shards.Total != 10 {
-			t.Errorf("Bad number of snapshot shards total")
-		}
-		if snapshotStats.Shards.Successful != 10 {
-			t.Errorf("Bad number of snapshot shards successful")
-		}
-		if len(repositoryStats.Snapshots) != 1 {
-			t.Errorf("Bad number of repository snapshots")
+		for repo, snapshotResponse := range stats {
+			if repo == "fail" {
+				if snapshotResponse.Snapshots != nil {
+					t.Errorf("Returning non-nil Snapshots response for inaccessible repo")
+				}
+				continue
+			} else {
+				if len(snapshotResponse.Snapshots[0].Indices) != 2 {
+					t.Errorf("Bad number of snapshot indices")
+				}
+				if len(snapshotResponse.Snapshots[0].Failures) != int(snapshotResponse.Snapshots[0].Shards.Failed) {
+					t.Errorf("Bad number of snapshot failures")
+				}
+				if snapshotResponse.Snapshots[0].Shards.Total != 2 {
+					t.Errorf("Bad number of snapshot shards total")
+				}
+				if snapshotResponse.Snapshots[0].Shards.Successful != 2 {
+					t.Errorf("Bad number of snapshot shards successful")
+				}
+				if len(snapshotResponse.Snapshots) != 1 {
+					t.Errorf("Bad number of repository snapshots")
+				}
+			}
 		}
 	}
 

--- a/hack/snapshots_test_setup.sh
+++ b/hack/snapshots_test_setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function get_test_case {
+
+  local es_version; es_version=$1
+  local containerID; containerID=$2
+  local doctype; doctype=$3
+
+  # Wait for ES to become available
+  while ! curl http://localhost:9200/_cluster/health >/dev/null 2>&1; do
+    sleep 2
+  done
+
+  # Create indices (made these explicit since defaults have changed since 5.4.2)
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/foo_1" -d '{"settings" : {"number_of_shards" : 1, "number_of_replicas" : 1}}' >/dev/null
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/foo_2" -d '{"settings" : {"number_of_shards" : 1, "number_of_replicas" : 1}}' >/dev/null
+
+  # Create events
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/foo_1/$doctype/1" -d '{"title":"abc","content":"hello"}' >/dev/null
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/foo_1/$doctype/2" -d '{"title":"def","content":"world"}' >/dev/null
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/foo_2/$doctype/1" -d '{"title":"abc001","content":"hello001"}' >/dev/null
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/foo_2/$doctype/2" -d '{"title":"def002","content":"world002"}' >/dev/null
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/foo_2/$doctype/3" -d '{"title":"def003","content":"world003"}' >/dev/null
+
+  # Create snapshot repositories
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/_snapshot/succeed" -d '{"type": "fs","settings":{"location": "/tmp/succeed"}}' >/dev/null
+  curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/_snapshot/fail" -d '{"type": "fs","settings":{"location": "/tmp/fail"}}' >/dev/null
+
+  # Create snapshots
+  curl -s -XPUT "http://localhost:9200/_snapshot/succeed/visible?wait_for_completion=true" >/dev/null
+  curl -s -XPUT "http://localhost:9200/_snapshot/fail/notvisible?wait_for_completion=true" >/dev/null
+
+  # Remove access to the "fail" repo
+  docker exec -it "$containerID" chmod 000 /tmp/fail
+
+  # Echo out test case responses
+  # shellcheck disable=SC2016
+  #echo "\"$es_version\": " '{`'"$(curl -s http://localhost:9200/_snapshot)"'`, `'"$(curl -s http://localhost:9200/_snapshot/succeed/_all)"'`, `'"$(curl -s http://localhost:9200/_snapshot/fail/_all)"'`},'
+
+  # Kill docker container
+  #docker kill "$containerID" >/dev/null
+}
+
+#get_test_case 5.6.16 "$(docker run -d --rm -p 9200:9200 -e xpack.security.enabled=false -e discovery.type=single-node -e path.repo=/tmp docker.elastic.co/elasticsearch/elasticsearch:5.6.16)" "type1"
+#get_test_case 6.8.8 "$(docker run -d --rm -p 9200:9200 -e xpack.security.enabled=false -e discovery.type=single-node -e path.repo=/tmp docker.elastic.co/elasticsearch/elasticsearch:6.8.8)" "type1"
+get_test_case 7.6.2 "$(docker run -d --rm -p 9200:9200 -e discovery.type=single-node -e path.repo=/tmp docker.elastic.co/elasticsearch/elasticsearch:7.5.2)" "_doc"


### PR DESCRIPTION
I've added support for a `snapshot_stats_repository_up` gauge which will report as down with a failed `/_snapshot/<name>/_all` scrape and report no further metric values for that repo in that case. I also added a hack folder with a script to make generating test cases a bit easier although I'd understand if you didn't want to include this! Let me know if you want anything changed.