### PR TITLE
add new options to specify list of exported indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ elasticsearch_exporter --help
 | es.indices               | 1.0.2                 | If true, query stats for indices in the cluster, based on es.indices-list. | false |
 | es.indices-list          | 1.1.1                 | Comma separated list or wildcard expression of index names in the cluster, for which stats should be exported. | * |
 | es.indices_settings      | 1.0.4rc1              | If true, query settings stats for indices in the cluster, based on es.indices_settings-list. | false |
-| es.indices_settings-list | 1.0.4rc1              | Comma separated list or wildcard expression of index names in the cluster, for which settings should be exported. | * |
+| es.indices_settings-list | 1.1.1                 | Comma separated list or wildcard expression of index names in the cluster, for which settings should be exported. | * |
 | es.shards                | 1.0.3rc1              | If true, query stats for all indices in the cluster, including shard-level stats (implies `es.indices=true`). | false |
 | es.snapshots             | 1.0.4rc1              | If true, query stats for the cluster snapshots. | false |
 | es.timeout               | 1.0.2                 | Timeout for trying to get stats from Elasticsearch. (ex: 20s) | 5s |

--- a/README.md
+++ b/README.md
@@ -41,24 +41,26 @@ Below is the command line options summary:
 elasticsearch_exporter --help
 ```
 
-| Argument                | Introduced in Version | Description | Default     |
-| --------                | --------------------- | ----------- | ----------- |
-| es.uri                  | 1.0.2                 | Address (host and port) of the Elasticsearch node we should connect to. This could be a local node (`localhost:9200`, for instance), or the address of a remote Elasticsearch server. When basic auth is needed, specify as: `<proto>://<user>:<password>@<host>:<port>`. E.G., `http://admin:pass@localhost:9200`. Special characters in the user credentials need to be URL-encoded. | http://localhost:9200 |
-| es.all                  | 1.0.2                 | If true, query stats for all nodes in the cluster, rather than just the node we connect to.                             | false |
-| es.cluster_settings     | 1.1.0rc1              | If true, query stats for cluster settings. | false |
-| es.indices              | 1.0.2                 | If true, query stats for all indices in the cluster. | false |
-| es.indices_settings     | 1.0.4rc1              | If true, query settings stats for all indices in the cluster. | false |
-| es.shards               | 1.0.3rc1              | If true, query stats for all indices in the cluster, including shard-level stats (implies `es.indices=true`). | false |
-| es.snapshots            | 1.0.4rc1              | If true, query stats for the cluster snapshots. | false |
-| es.timeout              | 1.0.2                 | Timeout for trying to get stats from Elasticsearch. (ex: 20s) | 5s |
-| es.ca                   | 1.0.2                 | Path to PEM file that contains trusted Certificate Authorities for the Elasticsearch connection. | |
-| es.client-private-key   | 1.0.2                 | Path to PEM file that contains the private key for client auth when connecting to Elasticsearch. | |
-| es.client-cert          | 1.0.2                 | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. | |
-| es.clusterinfo.interval | 1.1.0rc1              |  Cluster info update interval for the cluster label | 5m |
-| es.ssl-skip-verify      | 1.0.4rc1              | Skip SSL verification when connecting to Elasticsearch. | false |
-| web.listen-address      | 1.0.2                 | Address to listen on for web interface and telemetry. | :9114 |
-| web.telemetry-path      | 1.0.2                 | Path under which to expose metrics. | /metrics |
-| version                 | 1.0.2                 | Show version info on stdout and exit. | |
+| Argument                 | Introduced in Version | Description | Default     |
+| --------                 | --------------------- | ----------- | ----------- |
+| es.uri                   | 1.0.2                 | Address (host and port) of the Elasticsearch node we should connect to. This could be a local node (`localhost:9200`, for instance), or the address of a remote Elasticsearch server. When basic auth is needed, specify as: `<proto>://<user>:<password>@<host>:<port>`. E.G., `http://admin:pass@localhost:9200`. Special characters in the user credentials need to be URL-encoded. | http://localhost:9200 |
+| es.all                   | 1.0.2                 | If true, query stats for all nodes in the cluster, rather than just the node we connect to.                             | false |
+| es.cluster_settings      | 1.1.0rc1              | If true, query stats for cluster settings. | false |
+| es.indices               | 1.0.2                 | If true, query stats for indices in the cluster, based on es.indices-list. | false |
+| es.indices-list          | 1.1.1                 | Comma separated list or wildcard expression of index names in the cluster, for which stats should be exported. | * |
+| es.indices_settings      | 1.0.4rc1              | If true, query settings stats for indices in the cluster, based on es.indices_settings-list. | false |
+| es.indices_settings-list | 1.0.4rc1              | Comma separated list or wildcard expression of index names in the cluster, for which settings should be exported. | * |
+| es.shards                | 1.0.3rc1              | If true, query stats for all indices in the cluster, including shard-level stats (implies `es.indices=true`). | false |
+| es.snapshots             | 1.0.4rc1              | If true, query stats for the cluster snapshots. | false |
+| es.timeout               | 1.0.2                 | Timeout for trying to get stats from Elasticsearch. (ex: 20s) | 5s |
+| es.ca                    | 1.0.2                 | Path to PEM file that contains trusted Certificate Authorities for the Elasticsearch connection. | |
+| es.client-private-key    | 1.0.2                 | Path to PEM file that contains the private key for client auth when connecting to Elasticsearch. | |
+| es.client-cert           | 1.0.2                 | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. | |
+| es.clusterinfo.interval  | 1.1.0rc1              |  Cluster info update interval for the cluster label | 5m |
+| es.ssl-skip-verify       | 1.0.4rc1              | Skip SSL verification when connecting to Elasticsearch. | false |
+| web.listen-address       | 1.0.2                 | Address to listen on for web interface and telemetry. | :9114 |
+| web.telemetry-path       | 1.0.2                 | Path under which to expose metrics. | /metrics |
+| version                  | 1.0.2                 | Show version info on stdout and exit. | |
 
 Commandline parameters start with a single `-` for versions less than `1.1.0rc1`. 
 For versions greater than `1.1.0rc1`, commandline parameters are specified with `--`. Also, all commandline parameters can be provided as environment variables. The environment variable name is derived from the parameter name

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -14,9 +14,10 @@ import (
 
 // IndicesSettings information struct
 type IndicesSettings struct {
-	logger log.Logger
-	client *http.Client
-	url    *url.URL
+	logger      log.Logger
+	client      *http.Client
+	url         *url.URL
+	indicesList string
 
 	up                              prometheus.Gauge
 	readOnlyIndices                 prometheus.Gauge
@@ -24,11 +25,12 @@ type IndicesSettings struct {
 }
 
 // NewIndicesSettings defines Indices Settings Prometheus metrics
-func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *IndicesSettings {
+func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL, indicesList string) *IndicesSettings {
 	return &IndicesSettings{
-		logger: logger,
-		client: client,
-		url:    url,
+		logger:      logger,
+		client:      client,
+		url:         url,
+		indicesList: indicesList,
 
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, "indices_settings_stats", "up"),
@@ -87,8 +89,11 @@ func (cs *IndicesSettings) getAndParseURL(u *url.URL, data interface{}) error {
 
 func (cs *IndicesSettings) fetchAndDecodeIndicesSettings() (IndicesSettingsResponse, error) {
 
+	// Craft the url path for requesting stats for the selected indices
+	indexSettingsPath := fmt.Sprintf("/%s/_settings", cs.indicesList)
+
 	u := *cs.url
-	u.Path = path.Join(u.Path, "/_all/_settings")
+	u.Path = path.Join(u.Path, indexSettingsPath)
 	var asr IndicesSettingsResponse
 	err := cs.getAndParseURL(&u, &asr)
 	if err != nil {

--- a/collector/indices_settings_test.go
+++ b/collector/indices_settings_test.go
@@ -52,7 +52,7 @@ func TestIndicesSettings(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewIndicesSettings(log.NewNopLogger(), http.DefaultClient, u)
+			c := NewIndicesSettings(log.NewNopLogger(), http.DefaultClient, u, "*")
 			nsr, err := c.fetchAndDecodeIndicesSettings()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode indices settings: %s", err)

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -35,7 +35,7 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false, "*")
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/main.go
+++ b/main.go
@@ -41,9 +41,15 @@ func main() {
 		esExportIndices = kingpin.Flag("es.indices",
 			"Export stats for indices in the cluster.").
 			Default("false").Envar("ES_INDICES").Bool()
+		esExportIndicesList = kingpin.Flag("es.indices-list",
+			"Comma separated list or wildcard expression of index names in the cluster, for which stats should be exported.").
+			Default("*").Envar("ES_INDICES_LIST").String()
 		esExportIndicesSettings = kingpin.Flag("es.indices_settings",
 			"Export stats for settings of all indices of the cluster.").
 			Default("false").Envar("ES_INDICES_SETTINGS").Bool()
+		esExportIndicesSettingsList = kingpin.Flag("es.indices_settings-list",
+			"Comma separated list or wildcard expression of index names in the cluster, for which settings should be exported.").
+			Default("*").Envar("ES_INDICES_SETTINGS_LIST").String()
 		esExportClusterSettings = kingpin.Flag("es.cluster_settings",
 			"Export stats for cluster settings.").
 			Default("false").Envar("ES_CLUSTER_SETTINGS").Bool()
@@ -116,7 +122,7 @@ func main() {
 	prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes, *esNode))
 
 	if *esExportIndices || *esExportShards {
-		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards)
+		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards, *esExportIndicesList)
 		prometheus.MustRegister(iC)
 		if registerErr := clusterInfoRetriever.RegisterConsumer(iC); registerErr != nil {
 			_ = level.Error(logger).Log("msg", "failed to register indices collector in cluster info")
@@ -133,7 +139,7 @@ func main() {
 	}
 
 	if *esExportIndicesSettings {
-		prometheus.MustRegister(collector.NewIndicesSettings(logger, httpClient, esURL))
+		prometheus.MustRegister(collector.NewIndicesSettings(logger, httpClient, esURL, *esExportIndicesSettingsList))
 	}
 
 	// create a http server


### PR DESCRIPTION
Hi, 

First of all thanks for this awesome project!

As the `/_all/_stats` and `/_all/_settings` requests can be resource extensive, this PR adds options to specify a comma separated list of indices or wildcard index expressions, based on which the list of to be exported indices is determined.

This works in the same way as the `<index>` parameter here: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html

Options Added:

```
es.indices-list (default: *)
es.indices_settings-list (default: *)
```

Let me know if this is fine, or if there is anything else that needs to be adjusted.
Thanks for your help!
 